### PR TITLE
Add the vendored sonogram as a https dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1851,7 +1851,7 @@ checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 [[package]]
 name = "sonogram"
 version = "0.4.4"
-source = "git+ssh://git@github.com/hotg-ai/sonogram#39d4c4608e2a870fc3c7562eb3f1108010cf3087"
+source = "git+https://github.com/hotg-ai/sonogram#39d4c4608e2a870fc3c7562eb3f1108010cf3087"
 dependencies = [
  "hound",
  "num",

--- a/proc_blocks/fft/Cargo.toml
+++ b/proc_blocks/fft/Cargo.toml
@@ -9,4 +9,4 @@ edition = "2018"
 [dependencies]
 runic-types = { path = "../../runic-types" }
 hound = "3.4"
-sonogram = {git = "ssh://git@github.com/hotg-ai/sonogram"}
+sonogram = {git = "https://github.com/hotg-ai/sonogram"}


### PR DESCRIPTION
This is an alternative to #52 because the hotg-ai/sonogram repo is public.