### PR TITLE
Refactor Benchmarks

### DIFF
--- a/runtime/src/runtime.rs
+++ b/runtime/src/runtime.rs
@@ -38,6 +38,17 @@ impl Runtime {
         let module = Module::new(&store, rune)
             .context("WebAssembly compilation failed")?;
 
+        Runtime::load_from_module(&module, &store, env)
+    }
+
+    pub fn load_from_module<E>(
+        module: &Module,
+        store: &Store,
+        env: E,
+    ) -> Result<Self, Error>
+    where
+        E: Environment + Send + Sync + 'static,
+    {
         let env: Arc<dyn Environment> = Arc::new(env);
         let imports = import_object(&store, Arc::clone(&env));
         log::debug!("Instantiating the WebAssembly module");


### PR DESCRIPTION
Refactor how we implement the benchmarks so each case gets all the resources it needs.

I've also added module caching so we won't re-compile WebAssembly to machine code on every single pass through a benchmark. This opens the way to pre-compiled/cross-compiled Runes which can be executed without needing a JIT compiler (i.e. on iOS).

This fixes [this CI failure](https://github.com/hotg-ai/rune/runs/2103183644?check_suite_focus=true).