### PR TITLE
Internal Documentation

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -1,0 +1,5 @@
+# Table of Contents
+
+- [Rune as Containers](01.containers.md)
+- [Tutorial](tutorial.md)
+- [Exploration and Experiments](experiments/index.md)

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -1,0 +1,10 @@
+[book]
+authors = ["The Rune Developers"]
+src = "."
+title = "Rune Internal Docs"
+
+[build]
+build-dir = "../target/internal-docs"
+
+[output.html]
+default-theme = "rust"

--- a/docs/experiments/index.md
+++ b/docs/experiments/index.md
@@ -1,0 +1,36 @@
+# Exploration and Experiments
+
+A grab bag of interesting information we’ve discovered while implementing Rune.
+
+## Wasmer Memory Overhead
+
+The `wasmer` library compiles WebAssembly to machine code when we instantiate
+our Runtime. This means we get near-native performance, but also need to
+include an entire compiler and pay the (speed and memory) costs of
+compilation every time the Runtime is instantiated.
+
+Evaluating our "microspeech" Rune 1000 times and monitoring overall memory
+usage with [heaptrack][ht] shows:
+
+- About 1 second of compilation time before we can start executing the Rune
+- Compilation uses around 3MB
+- After compiling, memory usage drops to about 1.9MB (presumably the memory
+  associated with any compilation artifacts)
+- There is a tiny increase in memory usage (about 50 kb - you can’t really
+  tell) as we start executing the Rune, indicating that the "microspeech" Rune
+  only uses about 50 kb at runtime
+
+![Memory Overhead](./memory-overhead.png)
+
+This is significant because we could sacrifice runtime speed for lower memory
+usage on low memory devices (e.g. Arduino, STM32) by switching to an
+interpreted WebAssembly runtime like [`wasm3`][w3] or [`wasmi`][wi].
+
+Interpreters have considerably less overhead (mainly the WebAssembly stack,
+which we need anyway), so that means our current Runes are probably usable on
+embedded devices.
+
+
+[ht]: https://github.com/KDE/heaptrack
+[w3]: https://github.com/wasm3/wasm3
+[wi]: https://github.com/paritytech/wasmi


### PR DESCRIPTION
@kthakore mentioned it might be a good idea to write down my little "explorations" so we can use them for blog posts or documentation later on.

This makes our `docs/` folder compatible with [mdbook](https://github.com/rust-lang/mdBook), a tool that lets you generate online books from markdown files. I've also added some notes about the memory overhead findings I made last night.

TL;DR: 

```console
$ cargo install mdbook

$ cd path/to/rune/repo

$ mdbook serve docs --open
2021-03-26 14:54:52 [INFO] (mdbook::book): Book building has started
2021-03-26 14:54:52 [INFO] (mdbook::book): Running the html backend
2021-03-26 14:54:52 [INFO] (mdbook::cmd::serve): Serving on: http://localhost:3000
2021-03-26 14:54:52 [INFO] (warp::server): Server::run; addr=[::1]:3000
2021-03-26 14:54:52 [INFO] (warp::server): listening on http://[::1]:3000
2021-03-26 14:54:52 [INFO] (mdbook::cmd::watch): Listening for changes...
```

When we go public I'll wire up CI so that these internal docs and our API docs get published to GitHub Pages.

The whole thing may eventually be superseded by a proper Rune website powered by a static site generator, but in the meantime it should work well for our purposes.