### PR TITLE
Upload API docs to GitHub Pages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,9 +46,6 @@ jobs:
           cargo doc --workspace --verbose
           echo '<meta http-equiv="refresh" content="0; url=rune/index.html" />' > target/doc/index.html
         if: github.ref == 'refs/heads/master'
-        with:
-          command: doc
-          args: --workspace --verbose
       - name: Upload API Docs
         uses: JamesIves/github-pages-deploy-action@4.1.1
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,15 +26,32 @@ jobs:
           override: true
       - name: Install wasm32 target
         run: rustup target add wasm32-unknown-unknown x86_64-unknown-linux-musl
-      - uses: actions-rs/cargo@v1
+      - name: Type Check
+        uses: actions-rs/cargo@v1
         with:
           command: check
           args: --workspace --verbose
-      - uses: actions-rs/cargo@v1
+      - name: Build
+        uses: actions-rs/cargo@v1
         with:
           command: build
           args: --workspace --verbose
-      - uses: actions-rs/cargo@v1
+      - name: Test
+        uses: actions-rs/cargo@v1
         with:
           command: test
           args: --workspace --verbose
+      - name: Generate API Docs
+        run: |
+          cargo doc --workspace --verbose
+          echo '<meta http-equiv="refresh" content="0; url=rune/index.html" />' > target/doc/index.html
+        if: github.ref == 'refs/heads/master'
+        with:
+          command: doc
+          args: --workspace --verbose
+      - name: Upload API Docs
+        uses: JamesIves/github-pages-deploy-action@4.1.1
+        if: github.ref == 'refs/heads/master'
+        with:
+          branch: gh-pages
+          folder: target/doc

--- a/README.md
+++ b/README.md
@@ -2,27 +2,7 @@
 
 [![Continuous integration](https://github.com/hotg-ai/rune/actions/workflows/main.yml/badge.svg)](https://github.com/hotg-ai/rune/actions/workflows/main.yml)
 
-<table>
-   <thead>
-      <tr>
-         <th>Release</th>
-         <th>Download</th>
-      </tr>
-   </thead>
-   <tbody>
-      <tr>
-         <td>Nightly</td>
-         <td>
-            <li><a href="https://storage.cloud.google.com/rune-registry.appspot.com/nightly/rune.x86_64-unknown-linux-gnu.zip?authuser=1">
-               Linux (<code>x86_64-unknown-linux-gnu</code>)
-            </a></li>
-            <li>Windows (<code>x86_64-pc-windows-msvc</code>)</li>
-            <li>Mac (<code>x86_64-apple-darwin</code>)</li>
-            <li>iOS (<code>x86_64-apple-ios</code>)</li>
-         </td>
-         </tr>
-   </tbody>
-</table>
+**([Nightly Release][nightly] | [API Docs][api-docs])**
 
 Rune is a containerization technology for deploying TinyML applications to
 extremely constraint devices.
@@ -163,4 +143,5 @@ execute-sine  index.html  startup
 
 [xtask]: https://github.com/matklad/cargo-xtask
 [criterion]: https://bheisler.github.io/criterion.rs/book/criterion_rs.html
-
+[nightly]: https://github.com/hotg-ai/rune/releases/tag/nightly
+[api-docs]: https://hotg-ai.github.com/rune


### PR DESCRIPTION
Now the repo is public we can use GitHub Pages to host the nightly API docs.