### PR TITLE
Make "rune build" link to rune crates via git if they aren't available on disk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,6 +215,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "build-info"
+version = "0.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "569d94157949b69d52fd80b77a33cffa083ebcd7abf6d60999b41cc977664a32"
+dependencies = [
+ "build-info-common",
+ "build-info-proc",
+ "lazy_static",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "build-info-build"
+version = "0.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7975fa865b3562339bdec59ee877d2a8618c4f95dc0e4729f3d501818cae11b1"
+dependencies = [
+ "anyhow",
+ "base64",
+ "bincode",
+ "build-info-common",
+ "cargo_metadata",
+ "chrono",
+ "git2",
+ "glob",
+ "lazy_static",
+ "pretty_assertions",
+ "rustc_version",
+ "serde_json",
+ "xz2",
+]
+
+[[package]]
+name = "build-info-common"
+version = "0.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3210a1a81517312746d7ecad5cde4ad9d3ec20640cb6e0c9900c9c6aa6dea1"
+dependencies = [
+ "chrono",
+ "derive_more",
+ "semver",
+ "serde",
+]
+
+[[package]]
+name = "build-info-proc"
+version = "0.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22b0c07441c4c64c569cbf637e1e181b1c9c934764c7dcaac0ab7d8ffc8e1eba"
+dependencies = [
+ "anyhow",
+ "base64",
+ "bincode",
+ "build-info-common",
+ "chrono",
+ "format-buf",
+ "num-bigint",
+ "num-traits",
+ "proc-macro-error",
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn",
+ "xz2",
+]
+
+[[package]]
 name = "byte-tools"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -254,6 +322,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "camino"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4648c6d00a709aa069a236adcaae4f605a6241c72bf5bee79331a4b625921a9"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0226944a63d1bf35a3b5f948dd7c59e263db83695c9e8bffc4037de02e30f1d7"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "081e3f0755c1f380c2d010481b6fa2e02973586d5f2b24eebb7a2a1d98b143d8"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "semver-parser",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "cbindgen"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -277,6 +377,9 @@ name = "cc"
 version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cexpr"
@@ -298,6 +401,20 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "libc",
+ "num-integer",
+ "num-traits",
+ "serde",
+ "time",
+ "winapi",
+]
 
 [[package]]
 name = "clang-sys"
@@ -357,6 +474,12 @@ name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "cpp"
@@ -584,6 +707,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "0.99.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f82b1b72f1263f214c0f823371768776c4f5841b942c9883aa8e5ec584fd0ba6"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "devx-cmd"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -767,6 +902,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+dependencies = [
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
+name = "format-buf"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7aea5a5909a74969507051a3b17adc84737e31a5f910559892aedce026f4d53"
+
+[[package]]
 name = "fs-err"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -861,6 +1012,19 @@ name = "gimli"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
+
+[[package]]
+name = "git2"
+version = "0.13.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d250f5f82326884bd39c2853577e70a121775db76818ffa452ed1e80de12986"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
+]
 
 [[package]]
 name = "glob"
@@ -968,6 +1132,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
+name = "idna"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "if_rust_version"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1010,6 +1185,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
+name = "jobserver"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c71313ebb9439f74b00d9d2dcec36440beaf57a6aa0623068441dd7cd81a7f2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "jpeg-decoder"
 version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1043,6 +1227,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56d855069fafbb9b344c0f962150cd2c1187975cb1c22c1522c240d8c4986714"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.12.18+1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3da6a42da88fc37ee1ecda212ffa254c25713532980005d5f7c0b0fbe7e6e885"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libloading"
 version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1069,6 +1265,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 
 [[package]]
+name = "libz-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "602113192b08db8f38796c4e85c39e960c145965140e918018bcde1952429655"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "log"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1076,6 +1284,17 @@ checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if 1.0.0",
  "serde",
+]
+
+[[package]]
+name = "lzma-sys"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb4b7c3eddad11d3af9e86c487607d2d2442d185d848575365c4856ba96d619"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -1092,6 +1311,12 @@ name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
+name = "matches"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
 name = "maybe-owned"
@@ -1189,6 +1414,17 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-rational 0.4.0",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e0d047c1062aa51e256408c560894e5251f08925980e53cf1aa5bd00eec6512"
+dependencies = [
+ "autocfg",
+ "num-integer",
  "num-traits",
 ]
 
@@ -1312,6 +1548,12 @@ name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
+name = "percent-encoding"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "person_detection_agg"
@@ -1469,6 +1711,12 @@ dependencies = [
  "quote",
  "version_check",
 ]
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
@@ -1655,6 +1903,8 @@ version = "0.2.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
+ "build-info",
+ "build-info-build",
  "clap",
  "codespan-reporting",
  "dirs",
@@ -1799,6 +2049,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc_version"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1824,6 +2083,25 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser",
+ "serde",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
+dependencies = [
+ "pest",
+]
 
 [[package]]
 name = "serde"
@@ -2056,6 +2334,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b5220f05bb7de7f3f53c7c065e1199b3172696fe2db9f9c4d8ad9b4ee74c342"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
 name = "toml"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2115,6 +2408,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeb8be209bb1c96b7c177c7420d26e04eccacb0eeae6b980e35fcb74678107e0"
+dependencies = [
+ "matches",
+]
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07fbfce1c8a97d547e8b5334978438d9d6ec8c20e38f56d4a4374d181493eaef"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2131,6 +2442,24 @@ name = "unicode-xid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+
+[[package]]
+name = "url"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ccd964113622c8e9322cfac19eb1004a07e636c545f325da085d5cdde6f1f8b"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbdbff6266a24120518560b5dc983096efb98462e51d0d68169895b237be3e5d"
 
 [[package]]
 name = "vec_map"
@@ -2446,6 +2775,15 @@ dependencies = [
  "tflite",
  "walkdir",
  "zip",
+]
+
+[[package]]
+name = "xz2"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c179869f34fc7c01830d3ce7ea2086bc3a07e0d35289b667d0a8bf910258926c"
+dependencies = [
+ "lzma-sys",
 ]
 
 [[package]]

--- a/codegen/tests/smoke_test.rs
+++ b/codegen/tests/smoke_test.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use rune_codegen::Compilation;
+use rune_codegen::{Compilation, RuneProject};
 use rune_syntax::Diagnostics;
 use tempfile::TempDir;
 
@@ -22,10 +22,12 @@ fn we_can_compile_the_sine_example() {
         current_directory: sine_dir,
         working_directory: temp.path().to_path_buf(),
         optimized: false,
-        rune_project_dir: Path::new(env!("CARGO_MANIFEST_DIR"))
-            .parent()
-            .unwrap()
-            .to_path_buf(),
+        rune_project: RuneProject::Disk(
+            Path::new(env!("CARGO_MANIFEST_DIR"))
+                .parent()
+                .unwrap()
+                .to_path_buf(),
+        ),
     };
 
     if let Err(e) = rune_codegen::generate(compilation) {

--- a/ffi/tests/run_cxx_example.rs
+++ b/ffi/tests/run_cxx_example.rs
@@ -4,7 +4,7 @@ use std::{
 };
 use tempfile::TempDir;
 use rune_syntax::Diagnostics;
-use rune_codegen::Compilation;
+use rune_codegen::{Compilation, RuneProject};
 
 #[test]
 fn execute_cpp_example() {
@@ -69,7 +69,7 @@ fn execute_cpp_example() {
         rune: analysed,
         working_directory: temp.join("rust"),
         current_directory: ffi_dir.to_path_buf(),
-        rune_project_dir,
+        rune_project: RuneProject::Disk(rune_project_dir),
         optimized: false,
     };
     let compiled = rune_codegen::generate(c).unwrap();

--- a/rune/Cargo.toml
+++ b/rune/Cargo.toml
@@ -27,8 +27,12 @@ rune-wasmer-runtime = { path = "../wasmer-runtime" }
 rune-runtime = { path = "../runtime" }
 runicos-base = { path = "../images/runicos-base" }
 rand = "0.8.3"
+build-info = { version = "0.0.23", features = ["serde"] }
 
 [dev-dependencies]
 assert_cmd = "1.0.3"
 predicates = "1.0.7"
 tempfile = "3.2.0"
+
+[build-dependencies]
+build-info-build = "0.0.23"

--- a/rune/build.rs
+++ b/rune/build.rs
@@ -1,0 +1,1 @@
+fn main() { build_info_build::build_script(); }

--- a/rune/src/main.rs
+++ b/rune/src/main.rs
@@ -1,12 +1,16 @@
 mod build;
 mod graph;
 mod run;
+mod version;
 
 use std::str::FromStr;
-use crate::build::Build;
+use crate::{
+    build::Build,
+    version::{Format, Version},
+};
 use anyhow::Error;
 use codespan_reporting::term::termcolor;
-use structopt::StructOpt;
+use structopt::{clap::AppSettings, StructOpt};
 use env_logger::{Env, WriteStyle};
 use crate::run::Run;
 use crate::graph::Graph;
@@ -20,7 +24,12 @@ const DEFAULT_RUST_LOG: &str = concat!(
 );
 
 fn main() -> Result<(), Error> {
-    let Args { colour, cmd } = Args::from_args();
+    let Args {
+        colour,
+        cmd,
+        version,
+        verbose,
+    } = Args::from_args();
 
     let env = Env::new().default_filter_or(DEFAULT_RUST_LOG);
     env_logger::builder()
@@ -31,9 +40,26 @@ fn main() -> Result<(), Error> {
         .init();
 
     match cmd {
-        Cmd::Build(build) => build.execute(colour.into()),
-        Cmd::Run(run) => run.execute(),
-        Cmd::Graph(graph) => graph.execute(colour.into()),
+        Some(Cmd::Build(build)) => build.execute(colour.into()),
+        Some(Cmd::Run(run)) => run.execute(),
+        Some(Cmd::Graph(graph)) => graph.execute(colour.into()),
+        Some(Cmd::Version(mut version)) => {
+            version.verbose |= verbose;
+            version.execute()
+        },
+        None if version => {
+            let v = Version {
+                format: Format::Text,
+                verbose,
+            };
+            v.execute()
+        },
+        None => {
+            // we haven't been asked to print the version or execute a command,
+            // so just print out the usage and bail.
+            Args::clap().print_help()?;
+            Ok(())
+        },
     }
 }
 
@@ -47,8 +73,12 @@ pub struct Args {
         possible_values = &["always", "never", "auto"])
     ]
     colour: ColorChoice,
+    #[structopt(long, help = "Print out version information")]
+    version: bool,
+    #[structopt(short, long, help = "Prints even more detailed information")]
+    verbose: bool,
     #[structopt(subcommand)]
-    cmd: Cmd,
+    cmd: Option<Cmd>,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq)]
@@ -92,6 +122,7 @@ impl FromStr for ColorChoice {
 }
 
 #[derive(Debug, Clone, PartialEq, StructOpt)]
+#[structopt(setting(AppSettings::DisableVersion))]
 enum Cmd {
     /// Compile a Runefile into a Rune.
     Build(Build),
@@ -99,4 +130,6 @@ enum Cmd {
     Run(Run),
     /// Parse a Runefile and generate a DOT graph showing the pipelines inside.
     Graph(Graph),
+    /// Print detailed version information.
+    Version(Version),
 }

--- a/rune/src/main.rs
+++ b/rune/src/main.rs
@@ -73,7 +73,7 @@ pub struct Args {
         possible_values = &["always", "never", "auto"])
     ]
     colour: ColorChoice,
-    #[structopt(long, help = "Print out version information")]
+    #[structopt(short = "V", long, help = "Print out version information")]
     version: bool,
     #[structopt(short, long, help = "Prints even more detailed information")]
     verbose: bool,

--- a/rune/src/version.rs
+++ b/rune/src/version.rs
@@ -3,7 +3,7 @@ use build_info::{BuildInfo, GitInfo};
 use structopt::StructOpt;
 use std::{path::Path, str::FromStr};
 
-build_info::build_info!(fn version);
+build_info::build_info!(pub fn version);
 
 #[derive(Debug, Clone, PartialEq, StructOpt)]
 pub struct Version {

--- a/rune/src/version.rs
+++ b/rune/src/version.rs
@@ -1,0 +1,81 @@
+use anyhow::Error;
+use build_info::{BuildInfo, GitInfo};
+use structopt::StructOpt;
+use std::{path::Path, str::FromStr};
+
+build_info::build_info!(fn version);
+
+#[derive(Debug, Clone, PartialEq, StructOpt)]
+pub struct Version {
+    #[structopt(short, long)]
+    pub verbose: bool,
+    #[structopt(short, long, default_value = "text")]
+    pub format: Format,
+}
+
+impl Version {
+    pub fn execute(self) -> Result<(), Error> {
+        let binary = std::env::args().next().expect("");
+        let version = version();
+        let git = version.version_control.as_ref().unwrap().git().unwrap();
+
+        match self.format {
+            Format::Text => print_text(&binary, version, git, self.verbose),
+            Format::Json => todo!(),
+        }
+
+        Ok(())
+    }
+}
+
+fn print_text(binary: &str, version: &BuildInfo, git: &GitInfo, verbose: bool) {
+    let executable = Path::new(binary)
+        .file_name()
+        .and_then(|f| f.to_str())
+        .unwrap_or(binary);
+
+    // We want to copy rustc
+    // rustc 1.53.0-nightly (5a4ab2645 2021-04-18)
+    println!(
+        "{} {} ({} {})",
+        executable,
+        version.crate_info.version,
+        git.commit_short_id,
+        version.timestamp.format("%Y-%m-%d"),
+    );
+
+    if !verbose {
+        return;
+    }
+
+    println!("binary: {}", executable);
+    println!("rune-version: {}", version.crate_info.version);
+    println!("commit-hash: {}", git.commit_id);
+    println!("commit-date: {}", git.commit_timestamp.format("%Y-%m-%d"));
+    println!("host: {}", version.compiler.target_triple);
+    println!("rustc-version: {}", version.compiler.version);
+    if let Some(commit_hash) = version.compiler.commit_id.as_ref() {
+        println!("rustc-commit-hash: {}", commit_hash);
+    }
+    if let Some(commit_date) = version.compiler.commit_date {
+        println!("rustc-commit-date: {}", commit_date.format("%Y-%m-%d"));
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum Format {
+    Text,
+    Json,
+}
+
+impl FromStr for Format {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "text" => Ok(Format::Text),
+            "json" => Ok(Format::Json),
+            _ => Err(Error::msg("Expected \"text\" or \"json\"")),
+        }
+    }
+}


### PR DESCRIPTION
When linking to `runic_types` and our various proc blocks we used to *only* use path dependencies. This required the user to be inside a checkout of the `hotg-ai/rune` repository.

With this PR, we now fall back to using git dependencies if the path dependency isn't available, checking out the *exact* commit that the `rune` binary was compiled to. This is an interim measure until `runic_types` and our proc blocks are released on crates.io.

Because we now embed build information in the binary, I've updated our `rune --version` command to behave more like `rustc --version` and `rustc --version --verbose`.

```console
$ rune -V
rune 0.2.1 (4c85065 2021-04-19)
$ rune -Vv 
rune 0.2.1 (4c85065 2021-04-19)
binary: rune
rune-version: 0.2.1
commit-hash: 4c8506555a20bd8fbfcdcb56cc57e0f4292e16bb
commit-date: 2021-04-19
host: x86_64-unknown-linux-gnu
rustc-version: 1.53.0-nightly
rustc-commit-hash: 5a4ab26459a1ccf17ef5bb4c841d3ae5517b2890
rustc-commit-date: 2021-04-18
$ rune version
rune 0.2.1 (4c85065 2021-04-19)
$ rune version --verbose
rune 0.2.1 (4c85065 2021-04-19)
binary: rune
rune-version: 0.2.1
commit-hash: 4c8506555a20bd8fbfcdcb56cc57e0f4292e16bb
commit-date: 2021-04-19
host: x86_64-unknown-linux-gnu
rustc-version: 1.53.0-nightly
rustc-commit-hash: 5a4ab26459a1ccf17ef5bb4c841d3ae5517b2890
rustc-commit-date: 2021-04-18
```