### PR TITLE
Allow specifying the Rune project location in more fine-grained detail

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2102,6 +2102,7 @@ dependencies = [
  "rune-wasmer-runtime",
  "runic-types",
  "runicos-base",
+ "serde",
  "serde_json",
  "structopt",
  "tempfile",

--- a/rune/Cargo.toml
+++ b/rune/Cargo.toml
@@ -28,6 +28,7 @@ rune-runtime = { path = "../runtime" }
 runicos-base = { path = "../images/runicos-base" }
 rand = "0.8.3"
 build-info = { version = "0.0.23", features = ["serde"] }
+serde = { version = "1.0.125", features = ["derive"] }
 
 [dev-dependencies]
 assert_cmd = "1.0.3"

--- a/rune/src/build.rs
+++ b/rune/src/build.rs
@@ -53,7 +53,7 @@ impl Build {
             name,
             working_directory.display()
         );
-        let rune_project = match nearest_git_repo() {
+        let rune_project = match rune_repo_root() {
             Some(root_dir) => RuneProject::Disk(root_dir),
             None => {
                 // looks like we aren't into a checked out rune dir
@@ -127,11 +127,14 @@ impl Build {
     }
 }
 
-fn nearest_git_repo() -> Option<PathBuf> {
+fn rune_repo_root() -> Option<PathBuf> {
     let current_dir = std::env::current_dir().unwrap();
 
     for parent in current_dir.ancestors() {
-        if parent.join(".git").exists() {
+        if parent.join(".git").exists()
+            && parent.join("runic-types").exists()
+            && parent.join("proc_blocks").exists()
+        {
             return Some(parent.to_path_buf());
         }
     }

--- a/rune/src/build.rs
+++ b/rune/src/build.rs
@@ -3,7 +3,7 @@ use codespan_reporting::{
     files::SimpleFiles,
     term::{termcolor::StandardStream, Config, termcolor::ColorChoice},
 };
-use rune_codegen::{Compilation, RuneProject};
+use rune_codegen::{Compilation, GitSpecifier, RuneProject};
 use rune_syntax::{Diagnostics, hir::Rune};
 use std::{
     env::current_dir,
@@ -56,6 +56,7 @@ impl Build {
         let rune_project = match nearest_git_repo() {
             Some(root_dir) => RuneProject::Disk(root_dir),
             None => {
+                // looks like we aren't into a checked out rune dir
                 let build_info = crate::version::version();
                 let git = build_info
                     .version_control
@@ -63,7 +64,8 @@ impl Build {
                     .and_then(|v| v.git())
                     .context("Unable to determine the rune project dir")?;
                 RuneProject::Git {
-                    committish: git.commit_id.clone(),
+                    repo: RuneProject::GITHUB_REPO.into(),
+                    specifier: GitSpecifier::Commit(git.commit_id.clone()),
                 }
             },
         };

--- a/rune/src/version.rs
+++ b/rune/src/version.rs
@@ -1,7 +1,9 @@
 use anyhow::Error;
-use build_info::{BuildInfo, GitInfo};
+use build_info::{
+    chrono::{DateTime, NaiveDate, Utc},
+};
 use structopt::StructOpt;
-use std::{path::Path, str::FromStr};
+use std::{borrow::Cow, io::Write, path::Path, str::FromStr};
 
 build_info::build_info!(pub fn version);
 
@@ -15,33 +17,83 @@ pub struct Version {
 
 impl Version {
     pub fn execute(self) -> Result<(), Error> {
-        let binary = std::env::args().next().expect("");
+        let binary = std::env::args_os().next().expect("");
+        let executable = Path::new(&binary).file_name().unwrap_or(&binary);
+
         let version = version();
         let git = version.version_control.as_ref().unwrap().git().unwrap();
 
+        let info = VersionInfo {
+            executable: executable.to_string_lossy(),
+            rune_version: version.crate_info.version.to_string(),
+            commit_hash: &git.commit_id,
+            commit_short_hash: &git.commit_short_id,
+            commit_timestamp: git.commit_timestamp,
+            host: &version.compiler.target_triple,
+            rustc_version: version.compiler.version.to_string(),
+            rustc_commit_hash: version.compiler.commit_id.as_deref(),
+            rustc_commit_date: version.compiler.commit_date,
+        };
+
         match self.format {
-            Format::Text => print_text(&binary, version, git, self.verbose),
-            Format::Json => todo!(),
+            Format::Text => print_text(&info, self.verbose),
+            Format::Json => print_json(&info, self.verbose)?,
         }
 
         Ok(())
     }
 }
 
-fn print_text(binary: &str, version: &BuildInfo, git: &GitInfo, verbose: bool) {
-    let executable = Path::new(binary)
-        .file_name()
-        .and_then(|f| f.to_str())
-        .unwrap_or(binary);
+fn print_json(info: &VersionInfo, verbose: bool) -> Result<(), Error> {
+    let mut stdout = std::io::stdout();
+
+    if verbose {
+        serde_json::to_writer_pretty(&mut stdout, info)?;
+    } else {
+        serde_json::to_writer(&mut stdout, info)?;
+    }
+
+    writeln!(stdout)?;
+    stdout.flush()?;
+
+    Ok(())
+}
+
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "kebab-case")]
+struct VersionInfo<'a> {
+    executable: Cow<'a, str>,
+    rune_version: String,
+    commit_short_hash: &'a str,
+    commit_hash: &'a str,
+    commit_timestamp: DateTime<Utc>,
+    host: &'a str,
+    rustc_version: String,
+    rustc_commit_hash: Option<&'a str>,
+    rustc_commit_date: Option<NaiveDate>,
+}
+
+fn print_text(info: &VersionInfo<'_>, verbose: bool) {
+    let VersionInfo {
+        executable,
+        rune_version,
+        commit_short_hash,
+        commit_hash,
+        commit_timestamp,
+        host,
+        rustc_version,
+        rustc_commit_hash,
+        rustc_commit_date,
+    } = info;
 
     // We want to copy rustc
     // rustc 1.53.0-nightly (5a4ab2645 2021-04-18)
     println!(
         "{} {} ({} {})",
         executable,
-        version.crate_info.version,
-        git.commit_short_id,
-        version.timestamp.format("%Y-%m-%d"),
+        rune_version,
+        commit_short_hash,
+        commit_timestamp.format("%Y-%m-%d"),
     );
 
     if !verbose {
@@ -49,15 +101,15 @@ fn print_text(binary: &str, version: &BuildInfo, git: &GitInfo, verbose: bool) {
     }
 
     println!("binary: {}", executable);
-    println!("rune-version: {}", version.crate_info.version);
-    println!("commit-hash: {}", git.commit_id);
-    println!("commit-date: {}", git.commit_timestamp.format("%Y-%m-%d"));
-    println!("host: {}", version.compiler.target_triple);
-    println!("rustc-version: {}", version.compiler.version);
-    if let Some(commit_hash) = version.compiler.commit_id.as_ref() {
+    println!("rune-version: {}", rune_version);
+    println!("commit-hash: {}", commit_hash);
+    println!("commit-date: {}", commit_timestamp.to_rfc3339());
+    println!("host: {}", host);
+    println!("rustc-version: {}", rustc_version);
+    if let Some(commit_hash) = rustc_commit_hash {
         println!("rustc-commit-hash: {}", commit_hash);
     }
-    if let Some(commit_date) = version.compiler.commit_date {
+    if let Some(commit_date) = rustc_commit_date {
         println!("rustc-commit-date: {}", commit_date.format("%Y-%m-%d"));
     }
 }


### PR DESCRIPTION
This was originally triggered by [a conversation](https://hotg-ai.slack.com/archives/C01B8R53ZPV/p1619315411095100) with @kthakore on Slack. It now lets users of `rune-codegen` specify the Rune project's git repo via a commit, tag, or branch, not just commit.

@kthakore as a note, I'm not sure whether you'll want to be specifying the `master` branch here. If you do that, `hammerd` will always be using the latest and greatest Rune instead of a version it was tested with. I could see a scenario where the Rune project's `master` branch gets accidentally broken for a couple days (I dunno, say Michael side-stepped our CI and committed pushed to `master`, and now `runic-types` doesn't compile) and that causes all instances of `hammerd` to not be able to build runes or proc blocks.

If you want to find a known working commit, the `rune version` command has a JSON format you can read.

```console
$ rune version
rune 0.2.1 (e1d99dc 2021-04-25)
$ rune version --verbose --format json
{
  "executable": "rune",
  "rune-version": "0.2.1",
  "commit-short-hash": "e1d99dc",
  "commit-hash": "e1d99dcfb66c26e0e56c8a85786d7ba14ffafa4c",
  "commit-timestamp": "2021-04-25T07:54:31Z",
  "host": "x86_64-unknown-linux-gnu",
  "rustc-version": "1.53.0-nightly",
  "rustc-commit-hash": "7f4afdf0255600306bf67432da722c7b5d2cbf82",
  "rustc-commit-date": "2021-04-22"
}
```