### PR TITLE
Strip failures should be non-fatal

### DIFF
--- a/xtask/src/dist.rs
+++ b/xtask/src/dist.rs
@@ -196,7 +196,7 @@ fn strip_binaries(ctx: &Context) -> Result<(), Error> {
 
 fn strip_binary(path: &Path) -> Result<(), Error> {
     let mut cmd = Command::new("strip");
-    cmd.arg(&path);
+    cmd.arg(&path).arg("--strip-debug");
     log::debug!("Executing {:?}", cmd);
 
     let status = cmd.status().context("Unable to execute `strip`")?;


### PR DESCRIPTION
It looks like [`strip` failed on the Mac nightly build](https://github.com/hotg-ai/rune/runs/2456488163?check_suite_focus=true). Having stripped binaries is mainly a convenience, so if it fails we should just log a warning and keep going.