### PR TITLE
Type names in generated Rust code can't contain hyphens

### DIFF
--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -248,7 +248,7 @@ impl Generator {
             if let Some(name) = self.rune.names.get_name(id) {
                 let module_name = proc_block.name();
                 let type_name =
-                    format!("{}::{}", module_name, module_name.to_camel_case());
+                    format!("{}::{}", module_name, module_name.to_camel_case()).replace("-", "_");
 
                 let parameters = proc_block
                     .parameters

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -61,7 +61,7 @@ pub fn generate(c: Compilation) -> Result<Vec<u8>, Error> {
         .join("target")
         .join("wasm32-unknown-unknown")
         .join(build_dir)
-        .join(&generator.name)
+        .join(generator.name.replace("-", "_"))
         .with_extension("wasm");
 
     std::fs::read(&wasm)

--- a/codegen/tests/smoke_test.rs
+++ b/codegen/tests/smoke_test.rs
@@ -1,17 +1,21 @@
 use std::path::{Path, PathBuf};
-
 use rune_codegen::{Compilation, RuneProject};
-use rune_syntax::Diagnostics;
+use rune_syntax::{Diagnostics, hir::Rune};
 use tempfile::TempDir;
 
-#[test]
-fn we_can_compile_the_sine_example() {
-    let runefile = include_str!("../../examples/sine/Runefile");
-    let parsed = rune_syntax::parse(runefile).unwrap();
+fn load_runefile(src: &str) -> Rune {
+    let parsed = rune_syntax::parse(src).unwrap();
 
     let mut diags = Diagnostics::new();
     let rune = rune_syntax::analyse(&parsed, &mut diags);
     assert!(!diags.has_errors(), "{:?}", diags);
+
+    rune
+}
+
+#[test]
+fn we_can_compile_the_sine_example() {
+    let rune = load_runefile(include_str!("../../examples/sine/Runefile"));
 
     let temp = TempDir::new().unwrap();
     let sine_dir = project_root().join("examples").join("sine");
@@ -21,6 +25,32 @@ fn we_can_compile_the_sine_example() {
         rune,
         current_directory: sine_dir,
         working_directory: temp.path().to_path_buf(),
+        optimized: false,
+        rune_project: RuneProject::Disk(
+            Path::new(env!("CARGO_MANIFEST_DIR"))
+                .parent()
+                .unwrap()
+                .to_path_buf(),
+        ),
+    };
+
+    if let Err(e) = rune_codegen::generate(compilation) {
+        let path = temp.into_path();
+        panic!("Unable to compile in \"{}\": {}", path.display(), e);
+    }
+}
+
+#[test]
+fn paths_can_contain_hyphens() {
+    let rune = load_runefile("FROM runicos/base\n");
+
+    let temp = TempDir::new().unwrap();
+
+    let compilation = Compilation {
+        name: String::from("hyphen-ated"),
+        rune,
+        current_directory: temp.path().join("path-with-hyphens"),
+        working_directory: temp.path().join("build"),
         optimized: false,
         rune_project: RuneProject::Disk(
             Path::new(env!("CARGO_MANIFEST_DIR"))


### PR DESCRIPTION
@meelislootus this fixes your issue where the `noise-filtering` proc block has a hyphen and our `rune-codegen` tries using that as the proc block's namespace.

```
Meeliss-MacBook-Pro-3:rune meelislootus$ ./target/debug/rune build ./examples/microspeech/Runefile 
[2021-05-07T14:28:38.890Z DEBUG rune::build] Parsing "./examples/microspeech/Runefile"
[2021-05-07T14:28:38.891Z DEBUG rune::build] Compiling microspeech in "/Users/meelislootus/Library/Caches/runes/microspeech"
[2021-05-07T14:28:38.913Z DEBUG rune_codegen] Executing "cargo" "+nightly" "build" "--target=wasm32-unknown-unknown" "--quiet" "--release"
error[E0425]: cannot find value `noise` in this scope
 --> lib.rs:22:31
   |
22 |   let mut noise_filtering = noise-filtering::NoiseFiltering::default();
   |                ^^^^^ not found in this scopeerror[E0433]: failed to resolve: use of undeclared crate or module `filtering`
 --> lib.rs:22:48
   |
22 |   let mut noise_filtering = noise-filtering::NoiseFiltering::default();
   |                         ^^^^^^^^^^^^^^ not found in `filtering`
   |
help: consider importing this struct
   |
8  | use noise_filtering::NoiseFiltering;
   |error: aborting due to 2 previous errorsSome errors have detailed explanations: E0425, E0433.
For more information about an error, try `rustc --explain E0425`.
error: could not compile `microspeech`To learn more, run the command again with --verbose.
Error: Rune compilation failedCaused by:
  Compilation failed
```

Closes #145.