### PR TITLE
Allow arbitrary Rust expressions as part of capability/proc block arguments

### DIFF
--- a/examples/person_detection/Runefile
+++ b/examples/person_detection/Runefile
@@ -1,6 +1,6 @@
 FROM runicos/base
 
-CAPABILITY<U8[1, 96, 96]> image IMAGE
+CAPABILITY<U8[1, 96, 96]> image IMAGE --pixel-format @PixelFormat::GrayScale
 
 MODEL<U8[96, 96],U8[3]> person_detection ./model.tflite
 

--- a/proc_blocks/ohv_label/src/lib.rs
+++ b/proc_blocks/ohv_label/src/lib.rs
@@ -149,7 +149,6 @@ impl<const N: usize> Transform<Tensor<i8>> for OhvLabel<N> {
     }
 }
 
-
 impl<const N: usize> Default for OhvLabel<N> {
     fn default() -> Self { OhvLabel::new() }
 }

--- a/rune/src/run.rs
+++ b/rune/src/run.rs
@@ -120,7 +120,6 @@ fn initialize_image(capabilities: &[Capability]) -> Result<BaseImage, Error> {
                 let img = image::open(filename).with_context(|| {
                     format!("Unable to load \"{}\"", filename.display())
                 })?;
-                let img = img.to_rgb8();
                 env.with_image(move || Ok(Box::new(Image::new(img.clone()))));
             },
             Capability::Sound { filename } => {

--- a/rune/tests/integration.rs
+++ b/rune/tests/integration.rs
@@ -201,12 +201,10 @@ fn person_detection() {
         .arg("--capability")
         .arg(format!("image:{}", image.display()));
 
-    // FIXME: This should actually look for "person_prob" but it looks like our
-    // person detection rune isn't detecting people properly
     cmd.assert()
         .success()
         .code(0)
-        .stderr(predicates::str::contains("\"not_person_prob\""));
+        .stderr(predicates::str::contains("\"person_prob\""));
 }
 
 #[test]

--- a/runic-types/src/lib.rs
+++ b/runic-types/src/lib.rs
@@ -25,7 +25,7 @@ pub use crate::{
     tensor::{Tensor, TensorView},
     value::{Value, Type, AsType, InvalidConversionError},
 };
-
+use core::convert::TryFrom;
 use alloc::borrow::Cow;
 use log::{Level, Record};
 
@@ -134,24 +134,40 @@ impl<'a> Default for SerializableRecord<'a> {
 pub enum PixelFormat {
     RGB = 0,
     BGR = 1,
-    YUV = 2,
-    GrayScale = 3,
+    GrayScale = 2,
 }
 
 impl From<PixelFormat> for i32 {
-    fn from(p: PixelFormat) -> i32 {
-        p as i32
-    }
+    fn from(p: PixelFormat) -> i32 { p as i32 }
 }
 
 impl From<PixelFormat> for u32 {
-    fn from(p: PixelFormat) -> u32 {
-        p as u32
-    }
+    fn from(p: PixelFormat) -> u32 { p as u32 }
 }
 
 impl From<PixelFormat> for Value {
-    fn from(p: PixelFormat) -> Value {
-        Value::Integer(p.into())
+    fn from(p: PixelFormat) -> Value { Value::Integer(p.into()) }
+}
+
+impl TryFrom<i32> for PixelFormat {
+    type Error = &'static str;
+
+    fn try_from(i: i32) -> Result<PixelFormat, Self::Error> {
+        match i {
+            0 => Ok(PixelFormat::RGB),
+            1 => Ok(PixelFormat::BGR),
+            2 => Ok(PixelFormat::GrayScale),
+            _ => Err("Invalid value"),
+        }
+    }
+}
+
+impl TryFrom<Value> for PixelFormat {
+    type Error = &'static str;
+
+    fn try_from(value: Value) -> Result<PixelFormat, Self::Error> {
+        let integer = i32::try_from(value)
+            .map_err(|_| "Converting to an integer failed")?;
+        PixelFormat::try_from(integer)
     }
 }

--- a/runic-types/src/lib.rs
+++ b/runic-types/src/lib.rs
@@ -128,3 +128,30 @@ impl<'a> Default for SerializableRecord<'a> {
         }
     }
 }
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[repr(C)]
+pub enum PixelFormat {
+    RGB = 0,
+    BGR = 1,
+    YUV = 2,
+    GrayScale = 3,
+}
+
+impl From<PixelFormat> for i32 {
+    fn from(p: PixelFormat) -> i32 {
+        p as i32
+    }
+}
+
+impl From<PixelFormat> for u32 {
+    fn from(p: PixelFormat) -> u32 {
+        p as u32
+    }
+}
+
+impl From<PixelFormat> for Value {
+    fn from(p: PixelFormat) -> Value {
+        Value::Integer(p.into())
+    }
+}

--- a/runtime/src/common_capabilities/image.rs
+++ b/runtime/src/common_capabilities/image.rs
@@ -1,44 +1,114 @@
-use std::fmt::{self, Formatter, Debug};
-use anyhow::{Context, Error};
-use image::{GenericImageView, RgbImage};
+use std::{
+    fmt::{self, Formatter, Debug},
+    convert::TryFrom,
+};
+use anyhow::Error;
+use image::{GenericImageView, DynamicImage};
 use crate::{Capability, ParameterError};
+use runic_types::PixelFormat;
 
-#[derive(Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Image {
-    image: RgbImage,
+    processed_image: ProcessedImage,
 }
 
 impl Image {
-    pub fn new(image: RgbImage) -> Self { Image { image } }
+    pub fn new(image: DynamicImage) -> Self {
+        Image {
+            processed_image: ProcessedImage::new(image),
+        }
+    }
 }
 
 impl Capability for Image {
     fn generate(&mut self, buffer: &mut [u8]) -> Result<usize, Error> {
-        let raw = &self.image.as_flat_samples();
-        let raw = raw.image_slice().context("The image was malformed")?;
+        let bytes = self.processed_image.processed.as_bytes();
 
-        // lol, let's hope the caller knows how big their image is.
-        let len = std::cmp::min(raw.len(), buffer.len());
-        buffer[..len].copy_from_slice(&raw[..len]);
+        let len = std::cmp::min(bytes.len(), buffer.len());
+        buffer[..len].copy_from_slice(&bytes[..len]);
 
         Ok(len)
     }
 
     fn set_parameter(
         &mut self,
-        _name: &str,
-        _value: runic_types::Value,
+        name: &str,
+        value: runic_types::Value,
     ) -> Result<(), ParameterError> {
-        Err(ParameterError::UnsupportedParameter)
+        match name {
+            "pixel_format" => {
+                let format = PixelFormat::try_from(value).map_err(|e| {
+                    ParameterError::InvalidValue {
+                        value,
+                        reason: Error::msg(e),
+                    }
+                })?;
+
+                self.processed_image.set_pixel_format(format);
+                Ok(())
+            },
+            _ => {
+                log::warn!("Unknown parameter: \"{}\" = {}", name, value);
+                Ok(())
+            },
+        }
     }
 }
 
-impl Debug for Image {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let Image { image } = self;
+#[derive(Clone, PartialEq)]
+struct ProcessedImage {
+    original: DynamicImage,
+    processed: DynamicImage,
+}
 
-        let dims = image.dimensions();
-        let pixel = pixel_type_name(image);
+impl ProcessedImage {
+    fn new(original: DynamicImage) -> Self {
+        let processed = original.clone();
+
+        ProcessedImage {
+            original,
+            processed,
+        }
+    }
+
+    fn set_pixel_format(&mut self, pixel_format: PixelFormat) {
+        match pixel_format {
+            PixelFormat::GrayScale => {
+                self.processed =
+                    DynamicImage::ImageLuma8(self.original.to_luma8());
+            },
+            PixelFormat::RGB => {
+                self.processed =
+                    DynamicImage::ImageRgb8(self.original.to_rgb8());
+            },
+            PixelFormat::BGR => {
+                self.processed =
+                    DynamicImage::ImageBgr8(self.original.to_bgr8());
+            },
+        }
+    }
+}
+
+impl Debug for ProcessedImage {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let ProcessedImage {
+            original,
+            processed,
+        } = self;
+
+        f.debug_struct("ProcessedImage")
+            .field("original_", &DebugImage(original))
+            .field("pixel_type", &DebugImage(processed))
+            .finish()
+    }
+}
+
+struct DebugImage<'a>(&'a DynamicImage);
+
+impl<'a> Debug for DebugImage<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let dims = self.0.dimensions();
+        let pixel = pixel_type_name(self.0);
 
         f.debug_struct("Image")
             .field("dimensions", &dims)
@@ -47,9 +117,17 @@ impl Debug for Image {
     }
 }
 
-fn pixel_type_name<I>(_image: &I) -> &'static str
-where
-    I: GenericImageView,
-{
-    std::any::type_name::<I::Pixel>()
+fn pixel_type_name(image: &DynamicImage) -> &'static str {
+    match image {
+        DynamicImage::ImageLuma8(_) => "Luma8",
+        DynamicImage::ImageLumaA8(_) => "LumaA8",
+        DynamicImage::ImageRgb8(_) => "Rgb8",
+        DynamicImage::ImageRgba8(_) => "Rgba8",
+        DynamicImage::ImageBgr8(_) => "Bgr8",
+        DynamicImage::ImageBgra8(_) => "Bgra8",
+        DynamicImage::ImageLuma16(_) => "Luma16",
+        DynamicImage::ImageLumaA16(_) => "LumaA16",
+        DynamicImage::ImageRgb16(_) => "Rgb16",
+        DynamicImage::ImageRgba16(_) => "Rgba16",
+    }
 }

--- a/runtime/src/common_capabilities/mod.rs
+++ b/runtime/src/common_capabilities/mod.rs
@@ -1,8 +1,8 @@
 mod accelerometer;
 mod image;
 mod random;
-mod sound;
 mod raw;
+mod sound;
 
 use crate::ParameterError;
 

--- a/syntax/src/yaml/analysis.rs
+++ b/syntax/src/yaml/analysis.rs
@@ -1,7 +1,5 @@
 use std::collections::HashMap;
-use codespan_reporting::{
-    diagnostic::Diagnostic,
-};
+use codespan_reporting::{diagnostic::Diagnostic};
 use petgraph::graph::NodeIndex;
 use indexmap::IndexMap;
 use crate::{

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -2,9 +2,7 @@ mod bulk_copy;
 mod convert;
 mod dist;
 
-use crate::{
-    bulk_copy::BulkCopy, dist::Dist, convert::Convert,
-};
+use crate::{bulk_copy::BulkCopy, dist::Dist, convert::Convert};
 use std::path::{Path, PathBuf};
 use anyhow::{Context, Error};
 use devx_pre_commit::PreCommitContext;


### PR DESCRIPTION
This PR lets you use arbitrary, unescaped, Rust expressions as an argument's value.
The idea is we add a new `PixelFormat` enum to `runic-types` which then gets brought into scope via [our existing glob import](https://github.com/hotg-ai/rune/blob/99059c202fcd854cc944a42b0ae95146ceaa09c5/codegen/src/boilerplate/lib.rs.hbs#L8). This `PixelFormat` enum can be freely converted into a `runic_types::Value`, the primitive type used to pass values back and forth between a Rune and the runtime.

Whenever `rune-codegen` sees a string argument that starts with `@`, instead of quoting the argument it will paste the text in verbatim. That means when you have `--pixel-format PixelFormat::GrayScale` in your Runefile we'll generate `image.set_parameter("pixel_format", PixelFormat::RGB)`. This then gets [sent through to the runtime](https://github.com/hotg-ai/rune/blob/ef5704bc52cfbb156c3e1bf77c18f2d367fb218b/runic-types/src/wasm32/capability.rs#L63-L85) like normal.

As a working example I've also wired this up to the Rune CLI's builtin image capability and now the person detection Rune detects people properly!

@Ge-te in the flutter app we'll need to use [this enum](https://github.com/hotg-ai/rune/blob/ef5704bc52cfbb156c3e1bf77c18f2d367fb218b/runic-types/src/lib.rs#L132-L139) to figure out which pixel format to use.

closes #146.