### PR TITLE
Troubleshoot Nightly Wheel Issues

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
+            python/target
           key: ${{ runner.os }}-${{ github.workflow }}-${{ github.job }}-${{ hashFiles('**/Cargo.lock') }}
       - name: Update Rustup
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -146,6 +146,7 @@ jobs:
       - name: Print Artifacts
         run: ls -la nightly
       - uses: "marvinpinto/action-automatic-releases@latest"
+        if: github.ref == 'refs/heads/master'
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           automatic_release_tag: "nightly"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -59,7 +59,6 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
           key: ${{ runner.os }}-${{ github.workflow }}-${{ github.job }}-${{ hashFiles('**/Cargo.lock') }}
       - name: Setup Rust
         run: |
@@ -94,7 +93,6 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
           key: ${{ runner.os }}-${{ github.workflow }}-${{ github.job }}-${{ hashFiles('**/Cargo.lock') }}
       - name: Update Rustup
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -116,8 +116,10 @@ jobs:
                         --manylinux off \
                         --no-sdist \
                         --release
-          pip3 install target/wheels/*.whl
-          python3 -c 'from proc_blocks import Normalize; n = Normalize(); print(n([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))'
+      - name: Sanity Check
+        run: |
+          pip3 install target/wheels/rune_py*.whl
+          python3 -m unittest python/tests/integration_tests.py
       - name: Upload Wheels
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
It looks like the nightly build has been failing over the weekend because we'd generate a wheel but our sanity check (install the newly generated wheel and import it) failed.

Annotated output from [a failing build](https://github.com/hotg-ai/rune/runs/2592560410?check_suite_focus=true).

```console
$ maturin build --manifest-path python/Cargo.toml \
              --bindings pyo3 \
              --manylinux off \
              --no-sdist \
              --release
   Compiling rune_py v0.1.0 (/home/runner/work/rune/rune/python)
    Finished release [optimized] target(s) in 54.67s
📦 Built wheel for abi3 Python ≥ 3.6 to /home/runner/work/rune/rune/target/wheels/rune_py-0.1.0-cp36-abi3-linux_x86_64.whl

$ pip install target/wheels/*.whl
Processing ./target/wheels/rune_py-0.1.0-cp36-abi3-linux_x86_64.whl
Collecting numpy~=1.15
  Downloading numpy-1.19.5-cp36-cp36m-manylinux2010_x86_64.whl (14.8 MB)
Installing collected packages: numpy, rune-py
Successfully installed numpy-1.19.5 rune-py-0.1.0

$ python3 -c 'from proc_blocks import Normalize; n = Normalize(); print(n([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ImportError: cannot import name 'Normalize'
Error: Process completed with exit code 1.
```

Raised by @kthakore [on slack](https://hotg-ai.slack.com/archives/C01B8R53ZPV/p1621207339239200).

Log archive: [logs_604.zip](https://github.com/hotg-ai/rune/files/6490263/logs_604.zip)
