### PR TITLE
Removed all proc block builder methods in favour of setters

### DIFF
--- a/proc_blocks/fft/src/lib.rs
+++ b/proc_blocks/fft/src/lib.rs
@@ -83,7 +83,8 @@ impl ShortTimeFourierTransform {
         let power_spectrum_matrix: DMatrix<f64> =
             DMatrix::from_rows(&power_spectrum_vec);
         let mel_spectrum_matrix = &mel_filter_matrix * &power_spectrum_matrix;
-        let mel_spectrum_matrix = mel_spectrum_matrix.map(|energy| libm::sqrt(energy));
+        let mel_spectrum_matrix =
+            mel_spectrum_matrix.map(|energy| libm::sqrt(energy));
 
         let min_value = mel_spectrum_matrix
             .data
@@ -100,9 +101,7 @@ impl ShortTimeFourierTransform {
             .data
             .as_vec()
             .iter()
-            .map(|freq| {
-                65536.0 * (freq - min_value) / (max_value - min_value)
-            })
+            .map(|freq| 65536.0 * (freq - min_value) / (max_value - min_value))
             .map(|freq| freq as u32)
             .collect();
         let mut out = [0; 1960];
@@ -141,8 +140,8 @@ mod tests {
 
     #[test]
     fn it_works() {
-        let mut fft_pb =
-            ShortTimeFourierTransform::new().with_sample_rate(16000);
+        let mut fft_pb = ShortTimeFourierTransform::new();
+        fft_pb.set_sample_rate(16000);
         let input = Tensor::new_vector(vec![0; 16000]);
 
         let got = fft_pb.transform(input);

--- a/proc_blocks/fft/src/macros.rs
+++ b/proc_blocks/fft/src/macros.rs
@@ -1,20 +1,11 @@
 macro_rules! builder_methods {
     ($( $property:ident : $type:ty ),* $(,)?) => {
         $(
-            paste::paste! {
-                #[allow(dead_code)]
-                pub fn [< with_ $property >](mut self, $property: $type) -> Self {
-                    self.[< set_ $property >]($property);
-                    self
-                }
-            }
-        )*
-
-        $(
             #[allow(dead_code)]
             paste::paste! {
-                pub fn [< set_ $property >](&mut self, $property: $type) {
+                pub fn [< set_ $property >](&mut self, $property: $type) -> &mut Self {
                     self.$property = $property;
+                    self
                 }
             }
         )*

--- a/proc_blocks/noise-filtering/src/gain_control.rs
+++ b/proc_blocks/noise-filtering/src/gain_control.rs
@@ -184,8 +184,8 @@ mod tests {
     /// https://github.com/tensorflow/tensorflow/blob/0f6d728b920e9b0286171bdfec9917d8486ac08b/tensorflow/lite/experimental/microfrontend/lib/pcan_gain_control_test.cc#L43-L63
     #[test]
     fn test_pcan_gain_control() {
-        let mut gain_control =
-            GainControl::default().with_strength(0.95).with_offset(80.0);
+        let mut gain_control = GainControl::default();
+        gain_control.set_strength(0.95).set_offset(80.0);
         let input = Tensor::new_vector(vec![241137, 478104]);
         // Note: we get this from a the noise reduction step
         let noise_estimate = vec![6321887, 31248341];

--- a/proc_blocks/noise-filtering/src/lib.rs
+++ b/proc_blocks/noise-filtering/src/lib.rs
@@ -35,7 +35,6 @@ impl Transform<Tensor<u32>> for NoiseFiltering {
     type Output = Tensor<i8>;
 
     fn transform(&mut self, input: Tensor<u32>) -> Tensor<i8> {
-
         let cleaned = self.noise_reduction.transform(input);
 
         let amplified = self
@@ -43,18 +42,22 @@ impl Transform<Tensor<u32>> for NoiseFiltering {
             .transform(cleaned, &self.noise_reduction.noise_estimate())
             .map(|_, energy| libm::log2((*energy as f64) + 1.0));
 
-        let min_value = amplified.elements()
+        let min_value = amplified
+            .elements()
             .to_vec()
             .iter()
             .fold(f64::INFINITY, |a, &b| a.min(b));
 
-        let max_value = amplified.elements()
+        let max_value = amplified
+            .elements()
             .to_vec()
             .iter()
             .fold(f64::NEG_INFINITY, |a, &b| a.max(b));
 
-        let scaled = amplified.map(|_, energy| ((255.0 * (energy - min_value) /
-            (max_value - min_value)) - 128.0) as i8);
+        let scaled = amplified.map(|_, energy| {
+            ((255.0 * (energy - min_value) / (max_value - min_value)) - 128.0)
+                as i8
+        });
         scaled
     }
 }

--- a/proc_blocks/noise-filtering/src/macros.rs
+++ b/proc_blocks/noise-filtering/src/macros.rs
@@ -2,18 +2,9 @@ macro_rules! builder_methods {
     ($( $property:ident : $type:ty ),* $(,)?) => {
         $(
             paste::paste! {
-                #[allow(dead_code)]
-                pub fn [< with_ $property >](mut self, $property: $type) -> Self {
-                    self.[< set_ $property >]($property);
-                    self
-                }
-            }
-        )*
-
-        $(
-            paste::paste! {
-                pub fn [< set_ $property >](&mut self, $property: $type) {
+                pub fn [< set_ $property >](&mut self, $property: $type) -> &mut Self {
                     self.$property = $property;
+                    self
                 }
             }
         )*
@@ -32,18 +23,9 @@ macro_rules! defered_builder_methods {
     ($( $component:ident . $property:ident : $type:ty; )*) => {
         $(
             paste::paste! {
-                #[allow(dead_code)]
-                pub fn [< with_ $property >](mut self, $property: $type) -> Self {
-                    self.[< set_ $property >]($property);
-                    self
-                }
-            }
-        )*
-
-        $(
-            paste::paste! {
-                pub fn [< set_ $property >](&mut self, $property: $type) {
+                pub fn [< set_ $property >](&mut self, $property: $type) -> &mut Self {
                     self.$component.[< set_ $property >]($property);
+                    self
                 }
             }
         )*


### PR DESCRIPTION
This is just finishing off the work that was done in #158. We switched from generating `my_proc_block.with_count()` builder method calls for setting properties (`count`, in this case) over to `my_proc_block.set_count()` setters and this just removes the last of the builder methods now they are no longer needed.