### PR TITLE
Added aliases for providing capabilities to the rune CLI

### DIFF
--- a/rune/src/run.rs
+++ b/rune/src/run.rs
@@ -13,7 +13,8 @@ pub struct Run {
     /// The number of times to execute this rune
     #[structopt(short, long, default_value = "1")]
     repeats: usize,
-    /// Pass information to a capability as `key:value` pairs.
+    /// Initialize capabilities based on `key:value` pairs. Prefer to use
+    /// aliases like "--image" and "--sound" when the capability is builtin.
     ///
     /// For example:
     ///

--- a/rune/src/run.rs
+++ b/rune/src/run.rs
@@ -34,6 +34,38 @@ pub struct Run {
     /// - `raw:data.bin` is a file who's bytes will be used as-is
     #[structopt(short, long = "capability")]
     capabilities: Vec<Capability>,
+    #[structopt(
+        long = "accelerometer",
+        aliases = &["accel"],
+        parse(from_os_str),
+        help = "A CSV file containing [X, Y, Z] vectors to be returned by the ACCEL capability"
+    )]
+    accelerometer: Option<Vec<PathBuf>>,
+    #[structopt(
+        long,
+        parse(from_os_str),
+        help = "A WAV file containing samples returned by the SOUND capability"
+    )]
+    sound: Option<Vec<PathBuf>>,
+    #[structopt(
+        long,
+        aliases = &["img"],
+        parse(from_os_str),
+        help = "An image to be returned by the IMAGE capability"
+    )]
+    image: Option<Vec<PathBuf>>,
+    #[structopt(
+        long,
+        parse(from_os_str),
+        help = "A file who's bytes will be returned as-is by the RAW capability"
+    )]
+    raw: Option<Vec<PathBuf>>,
+    #[structopt(
+        long,
+        aliases = &["rand"],
+        help = "Seed the runtime's Random Number Generator"
+    )]
+    random: Option<u64>,
 }
 
 impl Run {
@@ -44,7 +76,9 @@ impl Run {
             format!("Unable to read \"{}\"", self.rune.display())
         })?;
 
-        let env = self.env().context("Unable to initialize the environment")?;
+        let capabilities = self.all_capabilities();
+        let env = initialize_image(&capabilities)
+            .context("Unable to initialize the environment")?;
 
         let mut runtime = Runtime::load(&rune, env)
             .context("Unable to initialize the virtual machine")?;
@@ -59,8 +93,50 @@ impl Run {
         Ok(())
     }
 
-    fn env(&self) -> Result<BaseImage, Error> {
-        initialize_image(&self.capabilities)
+    fn all_capabilities(&self) -> Vec<Capability> {
+        let Run {
+            capabilities,
+            accelerometer,
+            sound,
+            image,
+            raw,
+            random,
+            rune: _,
+            repeats: _,
+        } = self;
+        let mut caps = capabilities.clone();
+
+        if let Some(accel) = accelerometer {
+            extend_caps(&mut caps, accel, |p| Capability::accel(p));
+        }
+        if let Some(sound) = sound {
+            extend_caps(&mut caps, sound, |p| Capability::sound(p));
+        }
+        if let Some(raw) = raw {
+            extend_caps(&mut caps, raw, |p| Capability::raw(p));
+        }
+        if let Some(image) = image {
+            extend_caps(&mut caps, image, |p| Capability::image(p));
+        }
+        if let Some(random) = random {
+            caps.push(Capability::RandomSeed { seed: *random });
+        }
+
+        caps
+    }
+}
+
+fn extend_caps<'a, I, F, T>(
+    capabilities: &mut Vec<Capability>,
+    items: I,
+    mut map: F,
+) where
+    I: IntoIterator<Item = &'a T> + 'a,
+    T: 'a,
+    F: FnMut(&T) -> Capability,
+{
+    for item in items {
+        capabilities.push(map(item));
     }
 }
 
@@ -164,6 +240,32 @@ enum Capability {
     Image { filename: PathBuf },
     Sound { filename: PathBuf },
     Raw { filename: PathBuf },
+}
+
+impl Capability {
+    fn accel(filename: impl Into<PathBuf>) -> Self {
+        Capability::Accelerometer {
+            filename: filename.into(),
+        }
+    }
+
+    fn image(filename: impl Into<PathBuf>) -> Self {
+        Capability::Image {
+            filename: filename.into(),
+        }
+    }
+
+    fn sound(filename: impl Into<PathBuf>) -> Self {
+        Capability::Sound {
+            filename: filename.into(),
+        }
+    }
+
+    fn raw(filename: impl Into<PathBuf>) -> Self {
+        Capability::Raw {
+            filename: filename.into(),
+        }
+    }
 }
 
 impl FromStr for Capability {


### PR DESCRIPTION
This updates the `rune run` subcommand to make capabilities more discoverable. People can still use the `--capability image:person.png` syntax if they want, but we'd prefer them to use `--image person.png`.

The updated help text:

```console
$ rune run -h
Run a rune

USAGE:
    rune run [OPTIONS] <rune>

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
        --accelerometer <accelerometer>...    A CSV file containing [X, Y, Z] vectors to be returned by the ACCEL
                                              capability
    -c, --capability <capabilities>...        Initialize capabilities based on `key:value` pairs. Prefer to use aliases
                                              like "--image" and "--sound" when the capability is builtin
        --image <image>...                    An image to be returned by the IMAGE capability
        --random <random>                     Seed the runtime's Random Number Generator
        --raw <raw>...                        A file who's bytes will be returned as-is by the RAW capability
    -r, --repeats <repeats>                   The number of times to execute this rune [default: 1]
        --sound <sound>...                    A WAV file containing samples returned by the SOUND capability

ARGS:
    <rune>    The Rune to run
```

You also get a bunch more information, including examples like `--capability image:person.png`, if you use the longer `--help`:

```console
$ rune run --help
Run a rune

USAGE:
    rune run [OPTIONS] <rune>

FLAGS:
    -h, --help
            Prints help information

    -V, --version
            Prints version information


OPTIONS:
        --accelerometer <accelerometer>...
            A CSV file containing [X, Y, Z] vectors to be returned by the ACCEL capability

    -c, --capability <capabilities>...
            Initialize capabilities based on `key:value` pairs. Prefer to use aliases like "--image" and "--sound" when
            the capability is builtin.

            For example:

            - `random:42` seeds the random number generator with `42`

            - `random:random_bytes.bin` provides data to be returned by the random number generator

            - `accel:samples.csv` is a CSV file containing `[X, Y, Z]` vectors to be returned by the accelerometer

            - `sound:audio.wav` is a WAV file containing samples returned by the sound capability

            - `image:person.png` is an image file that will be returned by the image capability

            - `raw:data.bin` is a file who's bytes will be used as-is
        --image <image>...
            An image to be returned by the IMAGE capability

        --random <random>
            Seed the runtime's Random Number Generator

        --raw <raw>...
            A file who's bytes will be returned as-is by the RAW capability

    -r, --repeats <repeats>
            The number of times to execute this rune [default: 1]

        --sound <sound>...
            A WAV file containing samples returned by the SOUND capability


ARGS:
    <rune>
            The Rune to run
```

Fixes #169.