### PR TITLE
Add a "rune inspect" subcommand for inspecting runes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2172,9 +2172,11 @@ dependencies = [
  "serde",
  "serde_json",
  "structopt",
+ "strum",
  "tempfile",
  "tflite",
  "walkdir",
+ "wasmparser 0.78.2",
 ]
 
 [[package]]
@@ -2522,6 +2524,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "strum"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7318c509b5ba57f18533982607f24070a55d353e90d4cae30c467cdb2ad5ac5c"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8bc6b87a5112aeeab1f4a9f7ab634fe6cbefc4850006df31267f4cfb9e3149"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2835,7 +2858,7 @@ dependencies = [
  "thiserror",
  "wasmer-types",
  "wasmer-vm",
- "wasmparser",
+ "wasmparser 0.65.0",
 ]
 
 [[package]]
@@ -2977,6 +3000,12 @@ name = "wasmparser"
 version = "0.65.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87cc2fe6350834b4e528ba0901e7aa405d78b89dc1fa3145359eb4de0e323fcf"
+
+[[package]]
+name = "wasmparser"
+version = "0.78.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52144d4c78e5cf8b055ceab8e5fa22814ce4315d6002ad32cfd914f37c12fd65"
 
 [[package]]
 name = "wast"

--- a/codegen/src/code.rs
+++ b/codegen/src/code.rs
@@ -394,9 +394,12 @@ fn preamble(
     rune: &Rune,
     build_info: Option<serde_json::Value>,
 ) -> Result<TokenStream, Error> {
-    let rune_graph = custom_section("rune_graph", "RUNE_GRAPH", rune)?;
+    let rune_graph =
+        custom_section(crate::GRAPH_CUSTOM_SECTION, "RUNE_GRAPH", rune)?;
     let build_info = match build_info {
-        Some(v) => custom_section("rune_version", "RUNE_VERSION", &v)?,
+        Some(v) => {
+            custom_section(crate::VERSION_CUSTOM_SECTION, "RUNE_VERSION", &v)?
+        },
         None => quote!(),
     };
 

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -15,6 +15,9 @@ pub use crate::{
     project::Project,
 };
 
+pub const GRAPH_CUSTOM_SECTION: &str = ".rune_graph";
+pub const VERSION_CUSTOM_SECTION: &str = ".rune_version";
+
 use std::path::{PathBuf};
 use anyhow::{Context, Error};
 use rune_syntax::hir::Rune;

--- a/rune/Cargo.toml
+++ b/rune/Cargo.toml
@@ -30,6 +30,8 @@ rand = "0.8.3"
 build-info = { version = "0.0.23", features = ["serde"] }
 serde = { version = "1.0.125", features = ["derive"] }
 tflite = "0.9.5"
+strum = { version = "0.20.0", features = ["derive"] }
+wasmparser = "0.78.2"
 
 [dev-dependencies]
 assert_cmd = "1.0.3"

--- a/rune/src/inspect.rs
+++ b/rune/src/inspect.rs
@@ -1,0 +1,187 @@
+use std::{
+    collections::{BTreeMap, HashMap},
+    path::PathBuf,
+};
+use anyhow::{Context, Error};
+use build_info::BuildInfo;
+use rune_syntax::{
+    hir::{HirId, Rune, SourceKind},
+    yaml::{Type, Value},
+};
+use serde::{Serialize, Serializer};
+use strum::VariantNames;
+use wasmparser::{Parser, Payload};
+use crate::Format;
+
+#[derive(Debug, Clone, PartialEq, structopt::StructOpt)]
+pub struct Inspect {
+    #[structopt(
+        short,
+        long,
+        help = "The format to use when printing output",
+        default_value = "text",
+        possible_values = Format::VARIANTS,
+        parse(try_from_str)
+    )]
+    format: Format,
+    #[structopt(help = "The Rune to inspect", parse(from_os_str))]
+    rune: PathBuf,
+}
+
+impl Inspect {
+    pub fn execute(self) -> Result<(), Error> {
+        let wasm = std::fs::read(&self.rune).with_context(|| {
+            format!("Unable to read \"{}\"", self.rune.display())
+        })?;
+        let meta = Metadata::from_custom_sections(wasm_custom_sections(&wasm))
+            .context("unable to parse the Rune's metadata")?;
+
+        match self.format {
+            Format::Json => {
+                let s = serde_json::to_string_pretty(&meta)
+                    .context("Unable to format the metadata as JSON")?;
+                println!("{}", s);
+            },
+            Format::Text => todo!(),
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+struct Metadata {
+    version: Option<BuildInfo>,
+    rune: Option<SimplifiedRune>,
+}
+
+impl Metadata {
+    fn from_custom_sections<'a>(
+        sections: impl Iterator<Item = CustomSection<'a>>,
+    ) -> Result<Self, Error> {
+        let mut version = None;
+        let mut graph = None;
+
+        for section in sections {
+            match section.name {
+                "rune_graph" => {
+                    let rune: Rune = serde_json::from_slice(section.data)
+                        .context("Unable to deserialize the graph")?;
+                    graph = Some(SimplifiedRune::from(rune));
+                },
+                "rune_version" => {
+                    version = Some(
+                        serde_json::from_slice(section.data)
+                            .context("Unable to deserialize the version")?,
+                    );
+                },
+                _ => {},
+            }
+        }
+
+        Ok(Metadata {
+            version,
+            rune: graph,
+        })
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+struct SimplifiedRune {
+    capabilities: BTreeMap<String, SimplifiedCapability>,
+}
+
+impl From<Rune> for SimplifiedRune {
+    fn from(rune: Rune) -> Self {
+        let mut capabilities = BTreeMap::new();
+
+        for (&id, node) in &rune.stages {
+            let name = rune.names[id].to_string();
+            let outputs = node
+                .output_slots
+                .iter()
+                .map(|slot| rune.slots[slot].element_type)
+                .map(|type_id| resolve_type(&rune, type_id))
+                .collect();
+
+            match &node.stage {
+                rune_syntax::hir::Stage::Source(rune_syntax::hir::Source {
+                    kind,
+                    parameters,
+                }) => {
+                    let kind = kind.clone();
+                    let parameters = parameters.clone();
+                    capabilities.insert(
+                        name,
+                        SimplifiedCapability {
+                            capability_type: kind,
+                            parameters,
+                            outputs,
+                        },
+                    );
+                },
+                rune_syntax::hir::Stage::Sink(_) => {},
+                rune_syntax::hir::Stage::Model(_) => {},
+                rune_syntax::hir::Stage::ProcBlock(_) => {},
+            }
+        }
+
+        SimplifiedRune { capabilities }
+    }
+}
+
+fn resolve_type(rune: &Rune, type_id: HirId) -> Type {
+    let (primitive, dims) = match &rune.types[&type_id] {
+        rune_syntax::hir::Type::Primitive(p) => (p, vec![1]),
+        rune_syntax::hir::Type::Buffer {
+            underlying_type,
+            dimensions,
+        } => match &rune.types[underlying_type] {
+            rune_syntax::hir::Type::Primitive(p) => (p, dimensions.clone()),
+            _ => unreachable!(),
+        },
+        rune_syntax::hir::Type::Unknown | rune_syntax::hir::Type::Any => {
+            unreachable!("All types should have been resolved")
+        },
+    };
+
+    Type {
+        name: primitive.rust_name().to_string(),
+        dimensions: dims,
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+struct SimplifiedCapability {
+    #[serde(serialize_with = "serialize_source_kind")]
+    capability_type: SourceKind,
+    outputs: Vec<Type>,
+    parameters: HashMap<String, Value>,
+}
+
+fn serialize_source_kind<S: Serializer>(
+    kind: &SourceKind,
+    ser: S,
+) -> Result<S::Ok, S::Error> {
+    kind.to_string().serialize(ser)
+}
+
+fn wasm_custom_sections(
+    wasm: &[u8],
+) -> impl Iterator<Item = CustomSection<'_>> + '_ {
+    Parser::default()
+        .parse_all(wasm)
+        .filter_map(Result::ok)
+        .filter_map(|payload| match payload {
+            Payload::CustomSection { name, data, .. } => {
+                Some(CustomSection { name, data })
+            },
+            _ => None,
+        })
+}
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+struct CustomSection<'a> {
+    name: &'a str,
+    data: &'a [u8],
+}

--- a/rune/src/inspect.rs
+++ b/rune/src/inspect.rs
@@ -49,7 +49,7 @@ impl Inspect {
 }
 
 fn print_meta(meta: &Metadata) {
-    if let Some(build_info) = &meta.build_info {
+    if let Some(build_info) = &meta.rune_cli_build_info {
         let git = build_info
             .version_control
             .as_ref()
@@ -102,7 +102,7 @@ fn print_capabilities(capabilities: &BTreeMap<String, SimplifiedCapability>) {
 
 #[derive(Debug, Clone, serde::Serialize)]
 struct Metadata {
-    build_info: Option<BuildInfo>,
+    rune_cli_build_info: Option<BuildInfo>,
     rune: Option<SimplifiedRune>,
 }
 
@@ -110,7 +110,7 @@ impl Metadata {
     fn from_custom_sections<'a>(
         sections: impl Iterator<Item = CustomSection<'a>>,
     ) -> Self {
-        let mut version = None;
+        let mut rune_cli_build_info = None;
         let mut graph = None;
 
         for section in sections {
@@ -131,7 +131,7 @@ impl Metadata {
                 rune_codegen::VERSION_CUSTOM_SECTION => {
                     match serde_json::from_slice(section.data) {
                         Ok(v) => {
-                            version = Some(v);
+                            rune_cli_build_info = Some(v);
                         },
                         Err(e) => {
                             log::warn!(
@@ -146,7 +146,7 @@ impl Metadata {
         }
 
         Metadata {
-            build_info: version,
+            rune_cli_build_info,
             rune: graph,
         }
     }

--- a/rune/src/model_info.rs
+++ b/rune/src/model_info.rs
@@ -2,13 +2,15 @@ use std::{
     fmt::{self, Display, Formatter},
     io::Write,
     path::{Path, PathBuf},
-    str::FromStr,
 };
+use strum::VariantNames;
 use anyhow::{Error, Context};
 use tflite::{
     FlatBufferModel, Interpreter, InterpreterBuilder,
     ops::builtin::BuiltinOpResolver,
 };
+
+use crate::Format;
 
 #[derive(Debug, Clone, PartialEq, structopt::StructOpt)]
 pub struct ModelInfo {
@@ -20,8 +22,9 @@ pub struct ModelInfo {
     #[structopt(
         short,
         long,
-        help = "The format to print output in (supported: json, text)",
+        help = "The format to print output in",
         default_value = "text",
+        possible_values = Format::VARIANTS,
         parse(try_from_str)
     )]
     format: Format,
@@ -150,22 +153,4 @@ fn load_model(
         .context("Unable to initialize the model interpreter")?;
 
     Ok(interpreter)
-}
-
-#[derive(Debug, Copy, Clone, PartialEq)]
-enum Format {
-    Json,
-    Text,
-}
-
-impl FromStr for Format {
-    type Err = Error;
-
-    fn from_str(s: &str) -> Result<Self, Error> {
-        match s {
-            "json" => Ok(Format::Json),
-            "text" => Ok(Format::Text),
-            _ => Err(Error::msg("Expected \"json\" or \"text\"")),
-        }
-    }
 }

--- a/rune/src/version.rs
+++ b/rune/src/version.rs
@@ -3,7 +3,9 @@ use build_info::{
     chrono::{DateTime, NaiveDate, Utc},
 };
 use structopt::StructOpt;
-use std::{borrow::Cow, io::Write, path::Path, str::FromStr};
+use std::{borrow::Cow, io::Write, path::Path};
+use strum::VariantNames;
+use crate::Format;
 
 build_info::build_info!(pub fn version);
 
@@ -11,7 +13,7 @@ build_info::build_info!(pub fn version);
 pub struct Version {
     #[structopt(short, long)]
     pub verbose: bool,
-    #[structopt(short, long, default_value = "text")]
+    #[structopt(short, long, default_value = "text", possible_values = Format::VARIANTS)]
     pub format: Format,
 }
 
@@ -111,23 +113,5 @@ fn print_text(info: &VersionInfo<'_>, verbose: bool) {
     }
     if let Some(commit_date) = rustc_commit_date {
         println!("rustc-commit-date: {}", commit_date.format("%Y-%m-%d"));
-    }
-}
-
-#[derive(Debug, Copy, Clone, PartialEq)]
-pub enum Format {
-    Text,
-    Json,
-}
-
-impl FromStr for Format {
-    type Err = Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "text" => Ok(Format::Text),
-            "json" => Ok(Format::Json),
-            _ => Err(Error::msg("Expected \"text\" or \"json\"")),
-        }
     }
 }

--- a/syntax/src/hir.rs
+++ b/syntax/src/hir.rs
@@ -3,6 +3,7 @@
 use std::{
     collections::{HashMap, HashSet},
     convert::{TryFrom},
+    fmt::{self, Display, Formatter},
     hash::Hash,
     io::{Error, ErrorKind, Write},
     ops::Index,
@@ -465,6 +466,15 @@ impl<'a> From<&'a str> for SourceKind {
             "image" | "IMAGE" => SourceKind::Image,
             "raw" | "RAW" => SourceKind::Raw,
             _ => SourceKind::Other(s.to_string()),
+        }
+    }
+}
+
+impl Display for SourceKind {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            SourceKind::Other(custom) => Display::fmt(custom, f),
+            _ => write!(f, "{:?}", self),
         }
     }
 }


### PR DESCRIPTION
Continuing from #166, this adds a `rune inspect sine.rune` sub-command that lets you find out more about a Rune, in particular the Capabilities it uses.

```console
$ rune inspect person_detection.rune
Compiled by: rune v0.2.1 (c846a5b 2021-05-27)
Capabilities:
  image (Image)
    Outputs:
    - u8[1, 96, 96]
    Parameters:
    - height: Int(96)
    - width: Int(96)
    - pixel_format: String("@PixelFormat::GrayScale")
```

There is also a much richer JSON format you can use:

```console
$ rune inspect person_detection.rune --format json
{
  "build_info": {
    "timestamp": "2021-05-27T22:21:29.802283431Z",
    "profile": "debug",
    "optimization_level": 0,
    "crate_info": {
      "name": "rune",
      "version": "0.2.1",
      "authors": [
        "Kartik Thakore <kartik@thakore.ai>",
        "Akshay Sharma <akshay@sharma.ai>",
        "Michael-F-Bryan <consulting@michaelfbryan.com>"
      ],
      "license": "Apache 2.0",
      "enabled_features": [],
      "available_features": [],
      "dependencies": []
    },
    "compiler": {
      "version": "1.54.0-nightly",
      "commit_id": "881c1ac408d93bb7adaa3a51dabab9266e82eee8",
      "commit_date": "2021-05-08",
      "channel": "Nightly",
      "host_triple": "x86_64-unknown-linux-gnu",
      "target_triple": "x86_64-unknown-linux-gnu"
    },
    "version_control": {
      "Git": {
        "commit_id": "c846a5b8d058296176a0bf8df043a4b8e19f374c",
        "commit_short_id": "c846a5b",
        "commit_timestamp": "2021-05-27T22:05:25Z",
        "dirty": true,
        "branch": "feature/inspect",
        "tags": []
      }
    }
  },
  "rune": {
    "capabilities": {
      "image": {
        "capability_type": "Image",
        "outputs": [
          {
            "type": "u8",
            "dimensions": [
              1,
              96,
              96
            ]
          }
        ],
        "parameters": {
          "width": 96,
          "pixel_format": "@PixelFormat::GrayScale",
          "height": 96
        }
      }
    }
  }
}
```