### PR TITLE
Moved the generation of API docs to its own job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,6 +55,27 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: integration-tests
+
+  api-docs:
+    name: Generate API Docs
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-${{ github.workflow }}-${{ github.job }}-${{ hashFiles('**/Cargo.lock') }}
+      - name: Update Rustup
+        run: |
+          # We need to update rustup because the mac version is out of date and
+          # self-update is disabled. https://github.com/rust-lang/rustup/issues/2766
+          curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain none -y
+        if: runner.os == 'macOS'
+      - name: Setup Rust
+        run: rustup show
       - name: Generate API Docs
         run: |
           cargo doc --workspace --verbose --locked


### PR DESCRIPTION
Whenever we merge new code into `master`, the API docs build fails with an odd error. Hopefully by moving the `cargo doc` step to its own job it won't be contaminated by anything else and will be able to clear its cache (or whatever is breaking things). 

```
 Documenting rune-wasmer-runtime v0.1.0 (/home/runner/work/rune/rune/wasmer-runtime)
     Running `rustdoc --edition=2018 --crate-type lib --crate-name rune_wasmer_runtime wasmer-runtime/src/lib.rs -o /home/runner/work/rune/rune/target/doc --error-format=json --json=diagnostic-rendered-ansi -L dependency=/home/runner/work/rune/rune/target/debug/deps --extern anyhow=/home/runner/work/rune/rune/target/debug/deps/libanyhow-9787f58e2a6422c5.rmeta --extern log=/home/runner/work/rune/rune/target/debug/deps/liblog-3537f742ccc95852.rmeta --extern rune_runtime=/home/runner/work/rune/rune/target/debug/deps/librune_runtime-3c02218d72cb8df1.rmeta --extern runic_types=/home/runner/work/rune/rune/target/debug/deps/librunic_types-26ef521772bff0c2.rmeta --extern wasmer=/home/runner/work/rune/rune/target/debug/deps/libwasmer-15c3aabc8cd85080.rmeta --extern wasmer_types=/home/runner/work/rune/rune/target/debug/deps/libwasmer_types-d3de7877e17e7b2e.rmeta --extern wasmer_vm=/home/runner/work/rune/rune/target/debug/deps/libwasmer_vm-6c8bfd695e67a3e2.rmeta --crate-version 0.1.0`
 Documenting rune v0.2.1 (/home/runner/work/rune/rune/rune)
 Documenting rune-ffi v0.1.0 (/home/runner/work/rune/rune/ffi)
error: failed to remove directory `/home/runner/work/rune/rune/target/doc/rune/run`
Error: failed to remove directory `/home/runner/work/rune/rune/target/doc/rune/run`
Caused by:
  No such file or directory (os error 2)
warning: build failed, waiting for other jobs to finish...
Warning:      Running `rustdoc --edition=2018 --crate-type bin --crate-name rune rune/src/main.rs -o /home/runner/work/rune/rune/target/doc --error-format=json --json=diagnostic-rendered-ansi --document-private-items -L dependency=/home/runner/work/rune/rune/target/debug/deps --extern anyhow=/home/runner/work/rune/rune/target/debug/deps/libanyhow-9787f58e2a6422c5.rmeta --extern build_info=/home/runner/work/rune/rune/target/debug/deps/libbuild_info-fa28d6c6128ec235.rmeta --extern clap=/home/runner/work/rune/rune/target/debug/deps/libclap-4530ebaf1b41fdad.rmeta --extern codespan_reporting=/home/runner/work/rune/rune/target/debug/deps/libcodespan_reporting-3e97e880868116a2.rmeta --extern dirs=/home/runner/work/rune/rune/target/debug/deps/libdirs-9c6c3a6123438990.rmeta --extern env_logger=/home/runner/work/rune/rune/target/debug/deps/libenv_logger-30adc8ab82016992.rmeta --extern hound=/home/runner/work/rune/rune/target/debug/deps/libhound-e3218514bfa63aaf.rmeta --extern image=/home/runner/work/rune/rune/target/debug/deps/libimage-59736be3939b2670.rmeta --extern log=/home/runner/work/rune/rune/target/debug/deps/liblog-3537f742ccc95852.rmeta --extern once_cell=/home/runner/work/rune/rune/target/debug/deps/libonce_cell-2d5e1b80ee43e39d.rmeta --extern petgraph=/home/runner/work/rune/rune/target/debug/deps/libpetgraph-cecad510508f69d8.rmeta --extern rand=/home/runner/work/rune/rune/target/debug/deps/librand-d87d9c7ce9dbfa5e.rmeta --extern rune_codegen=/home/runner/work/rune/rune/target/debug/deps/librune_codegen-d1bd2a29c3a289af.rmeta --extern rune_runtime=/home/runner/work/rune/rune/target/debug/deps/librune_runtime-3c02218d72cb8df1.rmeta --extern rune_syntax=/home/runner/work/rune/rune/target/debug/deps/librune_syntax-edff6eac6ff64878.rmeta --extern rune_wasmer_runtime=/home/runner/work/rune/rune/target/debug/deps/librune_wasmer_runtime-8d7534fd05c08b2c.rmeta --extern runic_types=/home/runner/work/rune/rune/target/debug/deps/librunic_types-26ef521772bff0c2.rmeta --extern runicos_base=/home/runner/work/rune/rune/target/debug/deps/librunicos_base-b5fd7b58a7933819.rmeta --extern serde=/home/runner/work/rune/rune/target/debug/deps/libserde-06a6ec0c45f39771.rmeta --extern serde_json=/home/runner/work/rune/rune/target/debug/deps/libserde_json-39853c8c2a6dd335.rmeta --extern structopt=/home/runner/work/rune/rune/target/debug/deps/libstructopt-564b9b4e53635bd8.rmeta --extern tflite=/home/runner/work/rune/rune/target/debug/deps/libtflite-4028641800f9196e.rmeta --crate-version 0.2.1`
error: build failed
Error: Process completed with exit code 101.
```

[logs_686.zip](https://github.com/hotg-ai/rune/files/6557233/logs_686.zip)
