### PR TITLE
Troubleshoot unnecessary nightly releases

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -27,7 +27,7 @@ jobs:
           # causes git rev-list to fail) or when there are commits which are
           # accessible from this commit but not already under the nightly tag
 
-          commits_since_last_nightly=$(git rev-list ${{ github.sha }} '^nightly' 2>/dev/null)
+          commits_since_last_nightly=$(git rev-list ${{ github.sha }} '^nightly')
 
           if [ $? -eq 0 -a -z "$commits_since_last_nightly" ]; then
             echo "::set-output name=should_run::false"


### PR DESCRIPTION
I've noticed that we are generating new nightly releases even when there have been no new code changes. If possible, I'd like to avoid this because it uses up CI time and gives people the impression that work has been done when there hasn't... plus the daily notifications are kinda annoying.