### PR TITLE
Stop making unnecessary GitHub Releases

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,6 +16,8 @@ jobs:
       should_run: ${{ steps.should_run.outputs.should_run }}
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: print latest_commit
         run: echo ${{ github.sha }}
       - id: should_run


### PR DESCRIPTION
The "don't make a new release if there were no code changes" check wasn't working before because we didn't do a full clone of the repository in the `check_date` job. That meant we'd never see the previous `nightly` tag and think we need to make a new release.