### PR TITLE
Provide more fine-grained control over sub-command output

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,6 @@
 [alias]
-xtask = "run --package xtask --bin xtask --release --"
-rune = "run --package rune --release --quiet --"
+xtask = "run --package xtask --bin xtask --"
+rune = "run --package rune --"
 integration-tests = "run --package rune-integration-tests --"
 it = "integration-tests"
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,9 +52,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.40"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
+checksum = "15af2628f6890fe2609a3b91bef4c83450512802e59489f9c1cb1fa5df064a61"
 
 [[package]]
 name = "apodize"
@@ -115,7 +115,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "miniz_oxide 0.4.4",
- "object 0.25.2",
+ "object 0.25.3",
  "rustc-demangle",
 ]
 
@@ -272,9 +272,9 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "bytemuck"
-version = "1.5.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bed57e2090563b83ba8f83366628ce535a7584c9afa4c9fc0612a03925c6df58"
+checksum = "9966d2ab714d0f785dbac0a0396251a35280aeb42413281617d0209ab4898435"
 
 [[package]]
 name = "byteorder"
@@ -284,9 +284,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bzip2"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abf8012c8a15d5df745fcf258d93e6149dcf102882c8d8702d9cff778eab43a8"
+checksum = "6afcd980b5f3a45017c57e57a2fcccbb351cc43a356ce117ef760ef8052b89b0"
 dependencies = [
  "bzip2-sys",
  "libc",
@@ -294,9 +294,9 @@ dependencies = [
 
 [[package]]
 name = "bzip2-sys"
-version = "0.1.10+1.0.8"
+version = "0.1.11+1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17fa3d1ac1ca21c5c4e36a97f3c3eb25084576f6fc47bf0139c1123434216c6c"
+checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
 dependencies = [
  "cc",
  "libc",
@@ -828,9 +828,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17392a012ea30ef05a610aa97dfb49496e71c9f676b27879922ea5bdf60d9d3f"
+checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
 dependencies = [
  "atty",
  "humantime 2.1.0",
@@ -1006,9 +1006,9 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "globset"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c152169ef1e421390738366d2f796655fec62621dabbd0fd476f905934061e4a"
+checksum = "10463d9ff00a2a068db14231982f5132edebad0d7660cd956a1c30292dbcbfbd"
 dependencies = [
  "aho-corasick",
  "bstr",
@@ -1237,9 +1237,9 @@ checksum = "3576a87f2ba00f6f106fdfcd16db1d698d648a26ad8e0573cad8537c3c362d2a"
 
 [[package]]
 name = "libc"
-version = "0.2.95"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "789da6d93f1b866ffe175afc5322a4d76c038605a1c3319bb57b06967ca98a36"
+checksum = "12b8adadd720df158f4d70dfe7ccc6adb0472d7c55ca83445f6a5ab3e36f8fb6"
 
 [[package]]
 name = "libgit2-sys"
@@ -1350,9 +1350,9 @@ checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
 name = "matrixmultiply"
-version = "0.2.4"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916806ba0031cd542105d916a97c8572e1fa6dd79c9c51e7eb43a09ec2dd84c1"
+checksum = "5a8a15b776d9dfaecd44b03c5828c2199cddff5247215858aac14624f8d6b741"
 dependencies = [
  "rawpointer",
 ]
@@ -1455,12 +1455,12 @@ dependencies = [
 
 [[package]]
 name = "ndarray"
-version = "0.14.0"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c0d5c9540a691d153064dc47a4db2504587a75eae07bf1d73f7a596ebc73c04"
+checksum = "08e854964160a323e65baa19a0b1a027f76d590faba01f05c0cbc3187221a8c9"
 dependencies = [
  "matrixmultiply",
- "num-complex 0.3.1",
+ "num-complex 0.4.0",
  "num-integer",
  "num-traits",
  "rawpointer",
@@ -1606,14 +1606,14 @@ dependencies = [
 
 [[package]]
 name = "numpy"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7073fae1e0b82409533a29c6f804b79783d7b2d3c07728fdc4d884eda8cd4f0"
+checksum = "a996bcd58fb29bef9debf717330cd8876c3b4adbeea4939020a5326a3afad4d9"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
  "ndarray",
- "num-complex 0.3.1",
+ "num-complex 0.4.0",
  "num-traits",
  "pyo3",
 ]
@@ -1630,18 +1630,18 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.25.2"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bc1d42047cf336f0f939c99e97183cf31551bf0f2865a2ec9c8d91fd4ffb5e"
+checksum = "a38f2be3697a57b4060074ff41b44c16870d916ad7877c17696e063257482bc7"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.7.2"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
+checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
 name = "opaque-debug"
@@ -1939,9 +1939,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
+checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -1951,9 +1951,9 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
  "rand_core",
@@ -1961,18 +1961,18 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
  "getrandom",
 ]
 
 [[package]]
 name = "rand_hc"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
+checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
 dependencies = [
  "rand_core",
 ]
@@ -2010,9 +2010,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "742739e41cd49414de871ea5e549afb7e2a3ac77b589bcbebe8c82fab37147fc"
+checksum = "5ab49abadf3f9e1c4bc499e8845e152ad87d2ad2d30371841171169e9d75feee"
 dependencies = [
  "bitflags",
 ]
@@ -2094,7 +2094,7 @@ dependencies = [
  "clap",
  "codespan-reporting",
  "dirs",
- "env_logger 0.8.3",
+ "env_logger 0.8.4",
  "hound",
  "image",
  "indexmap",
@@ -2145,7 +2145,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cbindgen",
- "env_logger 0.8.3",
+ "env_logger 0.8.4",
  "libc",
  "log",
  "rune-codegen",
@@ -2162,7 +2162,7 @@ name = "rune-integration-tests"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "env_logger 0.8.3",
+ "env_logger 0.8.4",
  "log",
  "once_cell",
  "structopt",
@@ -2285,9 +2285,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "410f7acf3cb3a44527c5d9546bad4bf4e6c460915d5f9f2fc524498bfe8f70ce"
+checksum = "dead70b0b5e03e9c814bcb6b01e03e68f7c57a80aa48c72ec92152ab3e818d49"
 
 [[package]]
 name = "rustc-hash"
@@ -2403,7 +2403,7 @@ dependencies = [
 [[package]]
 name = "serde_yaml"
 version = "0.8.17"
-source = "git+https://github.com/hotg-ai/serde-yaml?branch=spans#91348d9fa88c945967691c555bccd2d26225332e"
+source = "git+https://github.com/hotg-ai/serde-yaml?branch=spans#6f6bb2d09f5d068e741a58d34f8c9b45e0191b14"
 dependencies = [
  "dtoa",
  "linked-hash-map",
@@ -2521,9 +2521,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.72"
+version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e8cdbefb79a9a5a65e0db8b47b723ee907b7c7f8496c76a1770b5c310bab82"
+checksum = "f71489ff30030d2ae598524f61326b902466f72a0fb1a8564c001cc63425bcc7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2570,9 +2570,9 @@ dependencies = [
 
 [[package]]
 name = "tflite"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8a7c3822e3c3aafa586481cbd41336ff8cc3b4c00527d129ded70dff11bdfc2"
+checksum = "5c868f33f8e73ac6c7ddd2d797a15dfccf360bfd3925868df8a3f93747b6734f"
 dependencies = [
  "bindgen",
  "cpp",
@@ -2616,11 +2616,12 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
  "libc",
+ "wasi",
  "winapi",
 ]
 
@@ -2754,9 +2755,9 @@ dependencies = [
 
 [[package]]
 name = "vcpkg"
-version = "0.2.13"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "025ce40a007e1907e58d5bc1a594def78e5573bb0b1160bc389634e8f12e4faa"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vec_map"
@@ -2792,9 +2793,9 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
+version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasmer"
@@ -2984,18 +2985,18 @@ checksum = "52144d4c78e5cf8b055ceab8e5fa22814ce4315d6002ad32cfd914f37c12fd65"
 
 [[package]]
 name = "wast"
-version = "35.0.2"
+version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ef140f1b49946586078353a453a1d28ba90adfc54dde75710bc1931de204d68"
+checksum = "8b5d7ba374a364571da1cb0a379a3dc302582a2d9937a183bfe35b68ad5bb9c4"
 dependencies = [
  "leb128",
 ]
 
 [[package]]
 name = "wat"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ec280a739b69173e0ffd12c1658507996836ba4e992ed9bc1e5385a0bd72a02"
+checksum = "16383df7f0e3901484c2dda6294ed6895caa3627ce4f6584141dcf30a33a23e6"
 dependencies = [
  "wast",
 ]
@@ -3064,7 +3065,7 @@ dependencies = [
  "cbindgen",
  "codespan-reporting",
  "devx-pre-commit",
- "env_logger 0.8.3",
+ "env_logger 0.8.4",
  "globset",
  "log",
  "rune-syntax",

--- a/ffi/tests/run_cxx_example.rs
+++ b/ffi/tests/run_cxx_example.rs
@@ -4,7 +4,7 @@ use std::{
 };
 use tempfile::TempDir;
 use rune_syntax::Diagnostics;
-use rune_codegen::{Compilation, RuneProject};
+use rune_codegen::{Compilation, RuneProject, Verbosity};
 
 #[test]
 fn execute_cpp_example() {
@@ -72,6 +72,7 @@ fn execute_cpp_example() {
         working_directory: temp.join("rust"),
         current_directory: ffi_dir.to_path_buf(),
         rune_project: RuneProject::Disk(rune_project_dir),
+        verbosity: Verbosity::Normal,
         optimized: false,
     };
     let compiled = rune_codegen::generate(c).unwrap();

--- a/rune/src/build.rs
+++ b/rune/src/build.rs
@@ -29,23 +29,23 @@ pub struct Build {
     #[structopt(short, long)]
     name: Option<String>,
     /// Hide output from tools that rune may call.
-    #[structopt(short, long)]
+    #[structopt(short, long, conflicts_with = "verbose")]
     quiet: bool,
+    /// Prints even more detailed information.
+    #[structopt(short, long, conflicts_with = "quiet")]
+    verbose: bool,
     /// Compile the Rune without optimisations.
     #[structopt(long)]
     debug: bool,
 }
 
 impl Build {
-    pub fn execute(
-        self,
-        color: ColorChoice,
-        verbose: bool,
-    ) -> Result<(), Error> {
-        let verbosity = Verbosity::from_quiet_and_verbose(self.quiet, verbose)
-            .context(
-                "The --verbose and --quiet flags can't be used together",
-            )?;
+    pub fn execute(self, color: ColorChoice) -> Result<(), Error> {
+        let verbosity =
+            Verbosity::from_quiet_and_verbose(self.quiet, self.verbose)
+                .context(
+                    "The --verbose and --quiet flags can't be used together",
+                )?;
 
         let rune = analyze(&self.runefile, color)?;
 

--- a/rune/src/main.rs
+++ b/rune/src/main.rs
@@ -40,7 +40,7 @@ fn main() -> Result<(), Error> {
         .init();
 
     match cmd {
-        Some(Cmd::Build(build)) => build.execute(colour.into()),
+        Some(Cmd::Build(build)) => build.execute(colour.into(), verbose),
         Some(Cmd::Run(run)) => run.execute(),
         Some(Cmd::Graph(graph)) => graph.execute(colour.into()),
         Some(Cmd::Version(mut version)) => {

--- a/rune/src/main.rs
+++ b/rune/src/main.rs
@@ -28,7 +28,6 @@ fn main() -> Result<(), Error> {
         colour,
         cmd,
         version,
-        verbose,
     } = Args::from_args();
 
     let env = Env::new().default_filter_or(DEFAULT_RUST_LOG);
@@ -40,19 +39,16 @@ fn main() -> Result<(), Error> {
         .init();
 
     match cmd {
-        Some(Cmd::Build(build)) => build.execute(colour.into(), verbose),
+        Some(Cmd::Build(build)) => build.execute(colour.into()),
         Some(Cmd::Run(run)) => run.execute(),
         Some(Cmd::Graph(graph)) => graph.execute(colour.into()),
-        Some(Cmd::Version(mut version)) => {
-            version.verbose |= verbose;
-            version.execute()
-        },
+        Some(Cmd::Version(version)) => version.execute(),
         Some(Cmd::ModelInfo(m)) => model_info::model_info(m),
         Some(Cmd::Inspect(i)) => i.execute(),
         None if version => {
             let v = Version {
                 format: Format::Text,
-                verbose,
+                verbose: false,
             };
             v.execute()
         },
@@ -75,10 +71,9 @@ pub struct Args {
         possible_values = ColorChoice::VARIANTS)
     ]
     colour: ColorChoice,
-    #[structopt(short = "V", long, help = "Print out version information")]
+    /// Prints out version information.
+    #[structopt(short = "V", long)]
     version: bool,
-    #[structopt(short, long, help = "Prints even more detailed information")]
-    verbose: bool,
     #[structopt(subcommand)]
     cmd: Option<Cmd>,
 }


### PR DESCRIPTION
In #202, @Mi1ind mentioned that we need some sort of progress indicator to let users know `rune` is waiting for `cargo` to finish compiling and hasn't just crashed.

I've altered the command line interface to behave more like `cargo`:

- building normally shows some general output
- using `--quiet` hides everything
- using `--verbose` shows all the `cargo` and `rustc` calls in explicit detail

The output from `rune build` now looks like this...

<details>
<summary>Building Normally</summary>

```console
$ rune build examples/noop/Runefile.yml
[2021-06-22T14:17:59.654Z INFO  rune_codegen::environment] Generating the project in "/home/michael/.cache/runes/noop"
    Updating crates.io index
   Compiling proc-macro2 v1.0.27
   Compiling unicode-xid v0.2.2
   Compiling syn v1.0.73
   Compiling serde_derive v1.0.126
   Compiling ryu v1.0.5
   Compiling serde v1.0.126
   Compiling log v0.4.14
   Compiling serde_json v1.0.64
   Compiling cfg-if v1.0.0
   Compiling itoa v0.4.7
   Compiling dlmalloc v0.2.1
   Compiling quote v1.0.9
   Compiling serde-json-core v0.4.0
   Compiling runic-types v0.1.0 (/home/michael/Documents/hotg-ai/rune/runic-types)
   Compiling runicos-base-wasm v0.1.0 (/home/michael/Documents/hotg-ai/rune/images/runicos-base/wasm)
   Compiling rune-pb-macros v0.1.0 (/home/michael/Documents/hotg-ai/rune/proc_blocks/macros)
   Compiling rune-pb-core v0.1.0 (/home/michael/Documents/hotg-ai/rune/proc_blocks/pb-core)
   Compiling noop v0.0.0 (/home/michael/.cache/runes/noop)
    Finished release [optimized] target(s) in 10.57s
```
</details>

<details>
<summary>Using the <code>--quiet</code> flag
</summary>

```console
$ rune build --quiet examples/noop/Runefile.yml
[2021-06-22T14:18:49.477Z INFO  rune_codegen::environment] Generating the project in "/home/michael/.cache/runes/noop"
```
</details>

<details>
<summary>Using the <code>--verbose</code> flag</summary>

```console
$ [2021-06-22T14:19:53.356Z INFO  rune_codegen::environment] Generating the project in "/home/michael/.cache/runes/noop"
    Updating crates.io index
   Compiling proc-macro2 v1.0.27
   Compiling unicode-xid v0.2.2
   Compiling syn v1.0.73
   Compiling serde_derive v1.0.126
   Compiling ryu v1.0.5
   Compiling serde v1.0.126
   Compiling log v0.4.14
     Running `/home/michael/.cargo/bin/sccache rustc --crate-name build_script_build --edition=2018 /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/proc-macro2-1.0.27/build.rs --error-format=json --json=diagnostic-rendered-ansi --crate-type bin --emit=dep-info,link -C embed-bitcode=no -C debug-assertions=off --cfg 'feature="default"' --cfg 'feature="proc-macro"' -C metadata=3a9ea7babb00e00e -C extra-filename=-3a9ea7babb00e00e --out-dir /home/michael/.cache/runes/noop/target/release/build/proc-macro2-3a9ea7babb00e00e -C linker=/usr/bin/clang -L dependency=/home/michael/.cache/runes/noop/target/release/deps --cap-lints allow`
     Running `/home/michael/.cargo/bin/sccache rustc --crate-name unicode_xid /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/unicode-xid-0.2.2/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debug-assertions=off --cfg 'feature="default"' -C metadata=0d367f75641c7e23 -C extra-filename=-0d367f75641c7e23 --out-dir /home/michael/.cache/runes/noop/target/release/deps -C linker=/usr/bin/clang -L dependency=/home/michael/.cache/runes/noop/target/release/deps --cap-lints allow`
     Running `/home/michael/.cargo/bin/sccache rustc --crate-name build_script_build --edition=2018 /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/syn-1.0.73/build.rs --error-format=json --json=diagnostic-rendered-ansi --crate-type bin --emit=dep-info,link -C embed-bitcode=no -C debug-assertions=off --cfg 'feature="clone-impls"' --cfg 'feature="default"' --cfg 'feature="derive"' --cfg 'feature="extra-traits"' --cfg 'feature="full"' --cfg 'feature="parsing"' --cfg 'feature="printing"' --cfg 'feature="proc-macro"' --cfg 'feature="quote"' -C metadata=d75a4486ddd6be34 -C extra-filename=-d75a4486ddd6be34 --out-dir /home/michael/.cache/runes/noop/target/release/build/syn-d75a4486ddd6be34 -C linker=/usr/bin/clang -L dependency=/home/michael/.cache/runes/noop/target/release/deps --cap-lints allow`
     Running `/home/michael/.cargo/bin/sccache rustc --crate-name build_script_build /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/serde_derive-1.0.126/build.rs --error-format=json --json=diagnostic-rendered-ansi --crate-type bin --emit=dep-info,link -C embed-bitcode=no -C debug-assertions=off --cfg 'feature="default"' -C metadata=6a040d3cd675c830 -C extra-filename=-6a040d3cd675c830 --out-dir /home/michael/.cache/runes/noop/target/release/build/serde_derive-6a040d3cd675c830 -C linker=/usr/bin/clang -L dependency=/home/michael/.cache/runes/noop/target/release/deps --cap-lints allow`
     Running `/home/michael/.cargo/bin/sccache rustc --crate-name build_script_build --edition=2018 /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/ryu-1.0.5/build.rs --error-format=json --json=diagnostic-rendered-ansi --crate-type bin --emit=dep-info,link -C embed-bitcode=no -C debug-assertions=off -C metadata=7e5577f606c2ed21 -C extra-filename=-7e5577f606c2ed21 --out-dir /home/michael/.cache/runes/noop/target/release/build/ryu-7e5577f606c2ed21 -C linker=/usr/bin/clang -L dependency=/home/michael/.cache/runes/noop/target/release/deps --cap-lints allow`
     Running `/home/michael/.cargo/bin/sccache rustc --crate-name build_script_build /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/serde-1.0.126/build.rs --error-format=json --json=diagnostic-rendered-ansi --crate-type bin --emit=dep-info,link -C embed-bitcode=no -C debug-assertions=off --cfg 'feature="alloc"' --cfg 'feature="derive"' --cfg 'feature="serde_derive"' -C metadata=025a6f7332205fdb -C extra-filename=-025a6f7332205fdb --out-dir /home/michael/.cache/runes/noop/target/release/build/serde-025a6f7332205fdb -C linker=/usr/bin/clang -L dependency=/home/michael/.cache/runes/noop/target/release/deps --cap-lints allow`
     Running `/home/michael/.cargo/bin/sccache rustc --crate-name build_script_build /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/log-0.4.14/build.rs --error-format=json --json=diagnostic-rendered-ansi --crate-type bin --emit=dep-info,link -C embed-bitcode=no -C debug-assertions=off --cfg 'feature="max_level_debug"' --cfg 'feature="max_level_trace"' --cfg 'feature="release_max_level_info"' --cfg 'feature="serde"' -C metadata=14cbbffc287cf7d9 -C extra-filename=-14cbbffc287cf7d9 --out-dir /home/michael/.cache/runes/noop/target/release/build/log-14cbbffc287cf7d9 -C linker=/usr/bin/clang -L dependency=/home/michael/.cache/runes/noop/target/release/deps --cap-lints allow`
     Running `/home/michael/.cargo/bin/sccache rustc --crate-name build_script_build /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/serde-1.0.126/build.rs --error-format=json --json=diagnostic-rendered-ansi --crate-type bin --emit=dep-info,link -C embed-bitcode=no -C debug-assertions=off --cfg 'feature="alloc"' --cfg 'feature="default"' --cfg 'feature="derive"' --cfg 'feature="serde_derive"' --cfg 'feature="std"' -C metadata=ec0579e095005060 -C extra-filename=-ec0579e095005060 --out-dir /home/michael/.cache/runes/noop/target/release/build/serde-ec0579e095005060 -C linker=/usr/bin/clang -L dependency=/home/michael/.cache/runes/noop/target/release/deps --cap-lints allow`
     Running `/home/michael/.cargo/bin/sccache rustc --crate-name build_script_build /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/log-0.4.14/build.rs --error-format=json --json=diagnostic-rendered-ansi --crate-type bin --emit=dep-info,link -C embed-bitcode=no -C debug-assertions=off --cfg 'feature="max_level_trace"' --cfg 'feature="serde"' -C metadata=66e23c45de69dbed -C extra-filename=-66e23c45de69dbed --out-dir /home/michael/.cache/runes/noop/target/release/build/log-66e23c45de69dbed -C linker=/usr/bin/clang -L dependency=/home/michael/.cache/runes/noop/target/release/deps --cap-lints allow`
   Compiling serde_json v1.0.64
     Running `/home/michael/.cargo/bin/sccache rustc --crate-name build_script_build --edition=2018 /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/serde_json-1.0.64/build.rs --error-format=json --json=diagnostic-rendered-ansi --crate-type bin --emit=dep-info,link -C embed-bitcode=no -C debug-assertions=off --cfg 'feature="default"' --cfg 'feature="std"' -C metadata=b5cb4af2f1b9a546 -C extra-filename=-b5cb4af2f1b9a546 --out-dir /home/michael/.cache/runes/noop/target/release/build/serde_json-b5cb4af2f1b9a546 -C linker=/usr/bin/clang -L dependency=/home/michael/.cache/runes/noop/target/release/deps --cap-lints allow`
   Compiling cfg-if v1.0.0
     Running `/home/michael/.cargo/bin/sccache rustc --crate-name cfg_if --edition=2018 /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/cfg-if-1.0.0/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts --crate-type lib --emit=dep-info,metadata,link -C opt-level=3 -C embed-bitcode=no -C metadata=1fe35b7cc021a44c -C extra-filename=-1fe35b7cc021a44c --out-dir /home/michael/.cache/runes/noop/target/wasm32-unknown-unknown/release/deps --target wasm32-unknown-unknown -L dependency=/home/michael/.cache/runes/noop/target/wasm32-unknown-unknown/release/deps -L dependency=/home/michael/.cache/runes/noop/target/release/deps --cap-lints allow -C link-arg=-s`
     Running `/home/michael/.cargo/bin/sccache rustc --crate-name cfg_if --edition=2018 /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/cfg-if-1.0.0/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debug-assertions=off -C metadata=a7a4d259bfa7f51e -C extra-filename=-a7a4d259bfa7f51e --out-dir /home/michael/.cache/runes/noop/target/release/deps -C linker=/usr/bin/clang -L dependency=/home/michael/.cache/runes/noop/target/release/deps --cap-lints allow`
   Compiling dlmalloc v0.2.1
     Running `/home/michael/.cargo/bin/sccache rustc --crate-name build_script_build /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/dlmalloc-0.2.1/build.rs --error-format=json --json=diagnostic-rendered-ansi --crate-type bin --emit=dep-info,link -C embed-bitcode=no -C debug-assertions=off --cfg 'feature="global"' -C metadata=90c0fa25b792c189 -C extra-filename=-90c0fa25b792c189 --out-dir /home/michael/.cache/runes/noop/target/release/build/dlmalloc-90c0fa25b792c189 -C linker=/usr/bin/clang -L dependency=/home/michael/.cache/runes/noop/target/release/deps --cap-lints allow`
     Running `/home/michael/.cargo/bin/sccache rustc --crate-name build_script_build --edition=2018 /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/serde_json-1.0.64/build.rs --error-format=json --json=diagnostic-rendered-ansi --crate-type bin --emit=dep-info,link -C embed-bitcode=no -C debug-assertions=off --cfg 'feature="alloc"' -C metadata=665d721eb64528df -C extra-filename=-665d721eb64528df --out-dir /home/michael/.cache/runes/noop/target/release/build/serde_json-665d721eb64528df -C linker=/usr/bin/clang -L dependency=/home/michael/.cache/runes/noop/target/release/deps --cap-lints allow`
   Compiling itoa v0.4.7
     Running `/home/michael/.cargo/bin/sccache rustc --crate-name itoa /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/itoa-0.4.7/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debug-assertions=off -C metadata=99109f8001c5968e -C extra-filename=-99109f8001c5968e --out-dir /home/michael/.cache/runes/noop/target/release/deps -C linker=/usr/bin/clang -L dependency=/home/michael/.cache/runes/noop/target/release/deps --cap-lints allow`
     Running `/home/michael/.cargo/bin/sccache rustc --crate-name itoa /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/itoa-0.4.7/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts --crate-type lib --emit=dep-info,metadata,link -C opt-level=3 -C embed-bitcode=no -C metadata=2a96909d9984cf6d -C extra-filename=-2a96909d9984cf6d --out-dir /home/michael/.cache/runes/noop/target/wasm32-unknown-unknown/release/deps --target wasm32-unknown-unknown -L dependency=/home/michael/.cache/runes/noop/target/wasm32-unknown-unknown/release/deps -L dependency=/home/michael/.cache/runes/noop/target/release/deps --cap-lints allow -C link-arg=-s`
     Running `/home/michael/.cache/runes/noop/target/release/build/log-14cbbffc287cf7d9/build-script-build`
     Running `/home/michael/.cache/runes/noop/target/release/build/serde_derive-6a040d3cd675c830/build-script-build`
     Running `/home/michael/.cache/runes/noop/target/release/build/ryu-7e5577f606c2ed21/build-script-build`
     Running `/home/michael/.cache/runes/noop/target/release/build/ryu-7e5577f606c2ed21/build-script-build`
     Running `/home/michael/.cache/runes/noop/target/release/build/serde-025a6f7332205fdb/build-script-build`
     Running `/home/michael/.cache/runes/noop/target/release/build/serde-ec0579e095005060/build-script-build`
     Running `/home/michael/.cache/runes/noop/target/release/build/log-66e23c45de69dbed/build-script-build`
     Running `/home/michael/.cache/runes/noop/target/release/build/syn-d75a4486ddd6be34/build-script-build`
     Running `/home/michael/.cache/runes/noop/target/release/build/proc-macro2-3a9ea7babb00e00e/build-script-build`
     Running `/home/michael/.cargo/bin/sccache rustc --crate-name ryu --edition=2018 /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/ryu-1.0.5/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts --crate-type lib --emit=dep-info,metadata,link -C opt-level=3 -C embed-bitcode=no -C metadata=f8e68b8e0d397772 -C extra-filename=-f8e68b8e0d397772 --out-dir /home/michael/.cache/runes/noop/target/wasm32-unknown-unknown/release/deps --target wasm32-unknown-unknown -L dependency=/home/michael/.cache/runes/noop/target/wasm32-unknown-unknown/release/deps -L dependency=/home/michael/.cache/runes/noop/target/release/deps --cap-lints allow -C link-arg=-s --cfg integer128 --cfg maybe_uninit`
     Running `/home/michael/.cargo/bin/sccache rustc --crate-name ryu --edition=2018 /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/ryu-1.0.5/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debug-assertions=off -C metadata=d9dfc6433e8f7c96 -C extra-filename=-d9dfc6433e8f7c96 --out-dir /home/michael/.cache/runes/noop/target/release/deps -C linker=/usr/bin/clang -L dependency=/home/michael/.cache/runes/noop/target/release/deps --cap-lints allow --cfg integer128 --cfg maybe_uninit`
     Running `/home/michael/.cargo/bin/sccache rustc --crate-name proc_macro2 --edition=2018 /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/proc-macro2-1.0.27/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debug-assertions=off --cfg 'feature="default"' --cfg 'feature="proc-macro"' -C metadata=5ae77545ab575611 -C extra-filename=-5ae77545ab575611 --out-dir /home/michael/.cache/runes/noop/target/release/deps -C linker=/usr/bin/clang -L dependency=/home/michael/.cache/runes/noop/target/release/deps --extern unicode_xid=/home/michael/.cache/runes/noop/target/release/deps/libunicode_xid-0d367f75641c7e23.rmeta --cap-lints allow --cfg lexerror_display --cfg hygiene --cfg use_proc_macro --cfg wrap_proc_macro --cfg proc_macro_span`
     Running `/home/michael/.cache/runes/noop/target/release/build/dlmalloc-90c0fa25b792c189/build-script-build`
     Running `/home/michael/.cargo/bin/sccache rustc --crate-name dlmalloc /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/dlmalloc-0.2.1/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts --crate-type lib --emit=dep-info,metadata,link -C opt-level=3 -C embed-bitcode=no --cfg 'feature="global"' -C metadata=b782ac167c394ed5 -C extra-filename=-b782ac167c394ed5 --out-dir /home/michael/.cache/runes/noop/target/wasm32-unknown-unknown/release/deps --target wasm32-unknown-unknown -L dependency=/home/michael/.cache/runes/noop/target/wasm32-unknown-unknown/release/deps -L dependency=/home/michael/.cache/runes/noop/target/release/deps --cap-lints allow -C link-arg=-s`
     Running `/home/michael/.cache/runes/noop/target/release/build/serde_json-b5cb4af2f1b9a546/build-script-build`
     Running `/home/michael/.cache/runes/noop/target/release/build/serde_json-665d721eb64528df/build-script-build`
   Compiling quote v1.0.9
     Running `/home/michael/.cargo/bin/sccache rustc --crate-name quote --edition=2018 /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/quote-1.0.9/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debug-assertions=off --cfg 'feature="default"' --cfg 'feature="proc-macro"' -C metadata=80af00654a2bd8a5 -C extra-filename=-80af00654a2bd8a5 --out-dir /home/michael/.cache/runes/noop/target/release/deps -C linker=/usr/bin/clang -L dependency=/home/michael/.cache/runes/noop/target/release/deps --extern proc_macro2=/home/michael/.cache/runes/noop/target/release/deps/libproc_macro2-5ae77545ab575611.rmeta --cap-lints allow`
     Running `/home/michael/.cargo/bin/sccache rustc --crate-name syn --edition=2018 /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/syn-1.0.73/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debug-assertions=off --cfg 'feature="clone-impls"' --cfg 'feature="default"' --cfg 'feature="derive"' --cfg 'feature="extra-traits"' --cfg 'feature="full"' --cfg 'feature="parsing"' --cfg 'feature="printing"' --cfg 'feature="proc-macro"' --cfg 'feature="quote"' -C metadata=daffd14f0e55260c -C extra-filename=-daffd14f0e55260c --out-dir /home/michael/.cache/runes/noop/target/release/deps -C linker=/usr/bin/clang -L dependency=/home/michael/.cache/runes/noop/target/release/deps --extern proc_macro2=/home/michael/.cache/runes/noop/target/release/deps/libproc_macro2-5ae77545ab575611.rmeta --extern quote=/home/michael/.cache/runes/noop/target/release/deps/libquote-80af00654a2bd8a5.rmeta --extern unicode_xid=/home/michael/.cache/runes/noop/target/release/deps/libunicode_xid-0d367f75641c7e23.rmeta --cap-lints allow`
     Running `/home/michael/.cargo/bin/sccache rustc --crate-name serde_derive /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/serde_derive-1.0.126/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi --crate-type proc-macro --emit=dep-info,link -C prefer-dynamic -C embed-bitcode=no -C debug-assertions=off --cfg 'feature="default"' -C metadata=c3a23f630eabc601 -C extra-filename=-c3a23f630eabc601 --out-dir /home/michael/.cache/runes/noop/target/release/deps -C linker=/usr/bin/clang -L dependency=/home/michael/.cache/runes/noop/target/release/deps --extern proc_macro2=/home/michael/.cache/runes/noop/target/release/deps/libproc_macro2-5ae77545ab575611.rlib --extern quote=/home/michael/.cache/runes/noop/target/release/deps/libquote-80af00654a2bd8a5.rlib --extern syn=/home/michael/.cache/runes/noop/target/release/deps/libsyn-daffd14f0e55260c.rlib --extern proc_macro --cap-lints allow --cfg underscore_consts`
     Running `/home/michael/.cargo/bin/sccache rustc --crate-name serde /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/serde-1.0.126/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts --crate-type lib --emit=dep-info,metadata,link -C opt-level=3 -C embed-bitcode=no --cfg 'feature="alloc"' --cfg 'feature="derive"' --cfg 'feature="serde_derive"' -C metadata=08b9363a7ebe4fa8 -C extra-filename=-08b9363a7ebe4fa8 --out-dir /home/michael/.cache/runes/noop/target/wasm32-unknown-unknown/release/deps --target wasm32-unknown-unknown -L dependency=/home/michael/.cache/runes/noop/target/wasm32-unknown-unknown/release/deps -L dependency=/home/michael/.cache/runes/noop/target/release/deps --extern serde_derive=/home/michael/.cache/runes/noop/target/release/deps/libserde_derive-c3a23f630eabc601.so --cap-lints allow -C link-arg=-s --cfg ops_bound --cfg core_reverse --cfg de_boxed_c_str --cfg de_boxed_path --cfg de_rc_dst --cfg core_duration --cfg integer128 --cfg range_inclusive --cfg num_nonzero --cfg serde_derive --cfg core_try_from --cfg num_nonzero_signed --cfg systemtime_checked_add`
     Running `/home/michael/.cargo/bin/sccache rustc --crate-name serde /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/serde-1.0.126/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debug-assertions=off --cfg 'feature="alloc"' --cfg 'feature="default"' --cfg 'feature="derive"' --cfg 'feature="serde_derive"' --cfg 'feature="std"' -C metadata=709aed8e0acdd274 -C extra-filename=-709aed8e0acdd274 --out-dir /home/michael/.cache/runes/noop/target/release/deps -C linker=/usr/bin/clang -L dependency=/home/michael/.cache/runes/noop/target/release/deps --extern serde_derive=/home/michael/.cache/runes/noop/target/release/deps/libserde_derive-c3a23f630eabc601.so --cap-lints allow --cfg ops_bound --cfg core_reverse --cfg de_boxed_c_str --cfg de_boxed_path --cfg de_rc_dst --cfg core_duration --cfg integer128 --cfg range_inclusive --cfg num_nonzero --cfg serde_derive --cfg core_try_from --cfg num_nonzero_signed --cfg systemtime_checked_add --cfg std_atomic64 --cfg std_atomic`
   Compiling serde-json-core v0.4.0
     Running `/home/michael/.cargo/bin/sccache rustc --crate-name serde_json --edition=2018 /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/serde_json-1.0.64/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts --crate-type lib --emit=dep-info,metadata,link -C opt-level=3 -C embed-bitcode=no --cfg 'feature="alloc"' -C metadata=b7603c65a6b69913 -C extra-filename=-b7603c65a6b69913 --out-dir /home/michael/.cache/runes/noop/target/wasm32-unknown-unknown/release/deps --target wasm32-unknown-unknown -L dependency=/home/michael/.cache/runes/noop/target/wasm32-unknown-unknown/release/deps -L dependency=/home/michael/.cache/runes/noop/target/release/deps --extern itoa=/home/michael/.cache/runes/noop/target/wasm32-unknown-unknown/release/deps/libitoa-2a96909d9984cf6d.rmeta --extern ryu=/home/michael/.cache/runes/noop/target/wasm32-unknown-unknown/release/deps/libryu-f8e68b8e0d397772.rmeta --extern serde=/home/michael/.cache/runes/noop/target/wasm32-unknown-unknown/release/deps/libserde-08b9363a7ebe4fa8.rmeta --cap-lints allow -C link-arg=-s --cfg limb_width_32`
     Running `/home/michael/.cargo/bin/sccache rustc --crate-name log /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/log-0.4.14/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts --crate-type lib --emit=dep-info,metadata,link -C opt-level=3 -C embed-bitcode=no --cfg 'feature="max_level_debug"' --cfg 'feature="max_level_trace"' --cfg 'feature="release_max_level_info"' --cfg 'feature="serde"' -C metadata=e297a6a47a0d8bef -C extra-filename=-e297a6a47a0d8bef --out-dir /home/michael/.cache/runes/noop/target/wasm32-unknown-unknown/release/deps --target wasm32-unknown-unknown -L dependency=/home/michael/.cache/runes/noop/target/wasm32-unknown-unknown/release/deps -L dependency=/home/michael/.cache/runes/noop/target/release/deps --extern cfg_if=/home/michael/.cache/runes/noop/target/wasm32-unknown-unknown/release/deps/libcfg_if-1fe35b7cc021a44c.rmeta --extern serde=/home/michael/.cache/runes/noop/target/wasm32-unknown-unknown/release/deps/libserde-08b9363a7ebe4fa8.rmeta --cap-lints allow -C link-arg=-s --cfg atomic_cas --cfg has_atomics`
     Running `/home/michael/.cargo/bin/sccache rustc --crate-name serde_json_core --edition=2018 /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/serde-json-core-0.4.0/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts --crate-type lib --emit=dep-info,metadata,link -C opt-level=3 -C embed-bitcode=no -C metadata=65dd5a8ac666a55e -C extra-filename=-65dd5a8ac666a55e --out-dir /home/michael/.cache/runes/noop/target/wasm32-unknown-unknown/release/deps --target wasm32-unknown-unknown -L dependency=/home/michael/.cache/runes/noop/target/wasm32-unknown-unknown/release/deps -L dependency=/home/michael/.cache/runes/noop/target/release/deps --extern ryu=/home/michael/.cache/runes/noop/target/wasm32-unknown-unknown/release/deps/libryu-f8e68b8e0d397772.rmeta --extern serde=/home/michael/.cache/runes/noop/target/wasm32-unknown-unknown/release/deps/libserde-08b9363a7ebe4fa8.rmeta --cap-lints allow -C link-arg=-s`
     Running `/home/michael/.cargo/bin/sccache rustc --crate-name log /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/log-0.4.14/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debug-assertions=off --cfg 'feature="max_level_trace"' --cfg 'feature="serde"' -C metadata=16bcd15a6bccc3c2 -C extra-filename=-16bcd15a6bccc3c2 --out-dir /home/michael/.cache/runes/noop/target/release/deps -C linker=/usr/bin/clang -L dependency=/home/michael/.cache/runes/noop/target/release/deps --extern cfg_if=/home/michael/.cache/runes/noop/target/release/deps/libcfg_if-a7a4d259bfa7f51e.rmeta --extern serde=/home/michael/.cache/runes/noop/target/release/deps/libserde-709aed8e0acdd274.rmeta --cap-lints allow --cfg atomic_cas --cfg has_atomics`
     Running `/home/michael/.cargo/bin/sccache rustc --crate-name serde_json --edition=2018 /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/serde_json-1.0.64/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debug-assertions=off --cfg 'feature="default"' --cfg 'feature="std"' -C metadata=0476b2550bb4feaa -C extra-filename=-0476b2550bb4feaa --out-dir /home/michael/.cache/runes/noop/target/release/deps -C linker=/usr/bin/clang -L dependency=/home/michael/.cache/runes/noop/target/release/deps --extern itoa=/home/michael/.cache/runes/noop/target/release/deps/libitoa-99109f8001c5968e.rmeta --extern ryu=/home/michael/.cache/runes/noop/target/release/deps/libryu-d9dfc6433e8f7c96.rmeta --extern serde=/home/michael/.cache/runes/noop/target/release/deps/libserde-709aed8e0acdd274.rmeta --cap-lints allow --cfg limb_width_64`
   Compiling runic-types v0.1.0 (/home/michael/Documents/hotg-ai/rune/runic-types)
     Running `/home/michael/.cargo/bin/sccache rustc --crate-name runic_types --edition=2018 /home/michael/Documents/hotg-ai/rune/runic-types/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts --crate-type lib --emit=dep-info,metadata,link -C opt-level=3 -C embed-bitcode=no --cfg 'feature="default"' -C metadata=87f294412d644e98 -C extra-filename=-87f294412d644e98 --out-dir /home/michael/.cache/runes/noop/target/wasm32-unknown-unknown/release/deps --target wasm32-unknown-unknown -L dependency=/home/michael/.cache/runes/noop/target/wasm32-unknown-unknown/release/deps -L dependency=/home/michael/.cache/runes/noop/target/release/deps --extern log=/home/michael/.cache/runes/noop/target/wasm32-unknown-unknown/release/deps/liblog-e297a6a47a0d8bef.rmeta --extern serde=/home/michael/.cache/runes/noop/target/wasm32-unknown-unknown/release/deps/libserde-08b9363a7ebe4fa8.rmeta -C link-arg=-s`
     Running `/home/michael/.cargo/bin/sccache rustc --crate-name runic_types --edition=2018 /home/michael/Documents/hotg-ai/rune/runic-types/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debug-assertions=off -C metadata=aef5f0a6043d5233 -C extra-filename=-aef5f0a6043d5233 --out-dir /home/michael/.cache/runes/noop/target/release/deps -C linker=/usr/bin/clang -L dependency=/home/michael/.cache/runes/noop/target/release/deps --extern log=/home/michael/.cache/runes/noop/target/release/deps/liblog-16bcd15a6bccc3c2.rmeta --extern serde=/home/michael/.cache/runes/noop/target/release/deps/libserde-709aed8e0acdd274.rmeta`
   Compiling runicos-base-wasm v0.1.0 (/home/michael/Documents/hotg-ai/rune/images/runicos-base/wasm)
     Running `/home/michael/.cargo/bin/sccache rustc --crate-name runicos_base_wasm --edition=2018 /home/michael/Documents/hotg-ai/rune/images/runicos-base/wasm/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi --crate-type lib --emit=dep-info,metadata,link -C opt-level=3 -C embed-bitcode=no -C metadata=ef3615d7ce75d59b -C extra-filename=-ef3615d7ce75d59b --out-dir /home/michael/.cache/runes/noop/target/wasm32-unknown-unknown/release/deps --target wasm32-unknown-unknown -L dependency=/home/michael/.cache/runes/noop/target/wasm32-unknown-unknown/release/deps -L dependency=/home/michael/.cache/runes/noop/target/release/deps --extern dlmalloc=/home/michael/.cache/runes/noop/target/wasm32-unknown-unknown/release/deps/libdlmalloc-b782ac167c394ed5.rmeta --extern log=/home/michael/.cache/runes/noop/target/wasm32-unknown-unknown/release/deps/liblog-e297a6a47a0d8bef.rmeta --extern runic_types=/home/michael/.cache/runes/noop/target/wasm32-unknown-unknown/release/deps/librunic_types-87f294412d644e98.rmeta --extern serde=/home/michael/.cache/runes/noop/target/wasm32-unknown-unknown/release/deps/libserde-08b9363a7ebe4fa8.rmeta --extern serde_json_core=/home/michael/.cache/runes/noop/target/wasm32-unknown-unknown/release/deps/libserde_json_core-65dd5a8ac666a55e.rmeta --extern serde_json=/home/michael/.cache/runes/noop/target/wasm32-unknown-unknown/release/deps/libserde_json-b7603c65a6b69913.rmeta -C link-arg=-s`
   Compiling rune-pb-macros v0.1.0 (/home/michael/Documents/hotg-ai/rune/proc_blocks/macros)
     Running `/home/michael/.cargo/bin/sccache rustc --crate-name rune_pb_macros --edition=2018 /home/michael/Documents/hotg-ai/rune/proc_blocks/macros/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi --crate-type proc-macro --emit=dep-info,link -C prefer-dynamic -C embed-bitcode=no -C debug-assertions=off -C metadata=0f6f0be8709f55a1 -C extra-filename=-0f6f0be8709f55a1 --out-dir /home/michael/.cache/runes/noop/target/release/deps -C linker=/usr/bin/clang -L dependency=/home/michael/.cache/runes/noop/target/release/deps --extern proc_macro2=/home/michael/.cache/runes/noop/target/release/deps/libproc_macro2-5ae77545ab575611.rlib --extern quote=/home/michael/.cache/runes/noop/target/release/deps/libquote-80af00654a2bd8a5.rlib --extern runic_types=/home/michael/.cache/runes/noop/target/release/deps/librunic_types-aef5f0a6043d5233.rlib --extern serde=/home/michael/.cache/runes/noop/target/release/deps/libserde-709aed8e0acdd274.rlib --extern serde_json=/home/michael/.cache/runes/noop/target/release/deps/libserde_json-0476b2550bb4feaa.rlib --extern syn=/home/michael/.cache/runes/noop/target/release/deps/libsyn-daffd14f0e55260c.rlib --extern proc_macro`
   Compiling rune-pb-core v0.1.0 (/home/michael/Documents/hotg-ai/rune/proc_blocks/pb-core)
     Running `/home/michael/.cargo/bin/sccache rustc --crate-name rune_pb_core --edition=2018 /home/michael/Documents/hotg-ai/rune/proc_blocks/pb-core/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi --crate-type lib --emit=dep-info,metadata,link -C opt-level=3 -C embed-bitcode=no -C metadata=cc494dc9233fada8 -C extra-filename=-cc494dc9233fada8 --out-dir /home/michael/.cache/runes/noop/target/wasm32-unknown-unknown/release/deps --target wasm32-unknown-unknown -L dependency=/home/michael/.cache/runes/noop/target/wasm32-unknown-unknown/release/deps -L dependency=/home/michael/.cache/runes/noop/target/release/deps --extern rune_pb_macros=/home/michael/.cache/runes/noop/target/release/deps/librune_pb_macros-0f6f0be8709f55a1.so --extern runic_types=/home/michael/.cache/runes/noop/target/wasm32-unknown-unknown/release/deps/librunic_types-87f294412d644e98.rmeta --extern serde=/home/michael/.cache/runes/noop/target/wasm32-unknown-unknown/release/deps/libserde-08b9363a7ebe4fa8.rmeta -C link-arg=-s`
   Compiling noop v0.0.0 (/home/michael/.cache/runes/noop)
     Running `/home/michael/.cargo/bin/sccache rustc --crate-name noop --edition=2018 lib.rs --error-format=json --json=diagnostic-rendered-ansi --crate-type cdylib --emit=dep-info,link -C opt-level=3 -C embed-bitcode=no -C metadata=a2f0404a64f3e27a --out-dir /home/michael/.cache/runes/noop/target/wasm32-unknown-unknown/release/deps --target wasm32-unknown-unknown -L dependency=/home/michael/.cache/runes/noop/target/wasm32-unknown-unknown/release/deps -L dependency=/home/michael/.cache/runes/noop/target/release/deps --extern log=/home/michael/.cache/runes/noop/target/wasm32-unknown-unknown/release/deps/liblog-e297a6a47a0d8bef.rlib --extern rune_pb_core=/home/michael/.cache/runes/noop/target/wasm32-unknown-unknown/release/deps/librune_pb_core-cc494dc9233fada8.rlib --extern runic_types=/home/michael/.cache/runes/noop/target/wasm32-unknown-unknown/release/deps/librunic_types-87f294412d644e98.rlib --extern runicos_base_wasm=/home/michael/.cache/runes/noop/target/wasm32-unknown-unknown/release/deps/librunicos_base_wasm-ef3615d7ce75d59b.rlib -C link-arg=-s`
    Finished release [optimized] target(s) in 8.08s
```
</details>