### PR TITLE
Initial implementation benchmarks for the rune cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,9 +353,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0226944a63d1bf35a3b5f948dd7c59e263db83695c9e8bffc4037de02e30f1d7"
+checksum = "cbdb825da8a5df079a43676dbe042702f1707b1109f713a01420fbb4cc71fa27"
 dependencies = [
  "serde",
 ]
@@ -1017,6 +1017,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
 
 [[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+
+[[package]]
 name = "generic-array"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1171,12 +1177,13 @@ dependencies = [
  "once_cell",
  "petgraph",
  "predicates 1.0.8",
- "rand",
+ "rand 0.8.4",
  "runecoral",
  "serde",
  "serde_json",
  "structopt",
  "strum",
+ "tempdir",
  "tempfile",
  "tflite",
  "walkdir",
@@ -1274,7 +1281,7 @@ dependencies = [
  "hound",
  "image",
  "log",
- "rand",
+ "rand 0.8.4",
  "thiserror",
 ]
 
@@ -1317,7 +1324,7 @@ dependencies = [
  "hotg-rune-runtime",
  "hotg-rune-wasmer-runtime",
  "log",
- "rand",
+ "rand 0.8.4",
  "serde_json",
  "syn",
  "tflite",
@@ -2203,9 +2210,9 @@ checksum = "57e35a3326b75e49aa85f5dc6ec15b41108cf5aee58eabb1f274dd18b73c2451"
 
 [[package]]
 name = "predicates-tree"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f553275e5721409451eb85e15fd9a860a6e5ab4496eb215987502b5f5391f2"
+checksum = "d7dd0fd014130206c9352efbdc92be592751b2b9274dff685348341082c6ea3d"
 dependencies = [
  "predicates-core",
  "treeline",
@@ -2338,13 +2345,26 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+dependencies = [
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.3.1",
+ "rdrand",
+ "winapi",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.3",
  "rand_hc",
 ]
 
@@ -2355,8 +2375,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.3",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -2373,7 +2408,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -2405,6 +2440,15 @@ dependencies = [
  "crossbeam-utils",
  "lazy_static",
  "num_cpus",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -2863,6 +2907,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0652da4c4121005e9ed22b79f6c5f2d9e2752906b53a33e9490489ba421a6fb"
 
 [[package]]
+name = "tempdir"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
+dependencies = [
+ "rand 0.4.6",
+ "remove_dir_all",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2870,7 +2924,7 @@ checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "rand",
+ "rand 0.8.4",
  "redox_syscall",
  "remove_dir_all",
  "winapi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,6 +226,7 @@ dependencies = [
  "lazy_static",
  "memchr",
  "regex-automata",
+ "serde",
 ]
 
 [[package]]
@@ -256,7 +257,7 @@ dependencies = [
  "glob",
  "lazy_static",
  "pretty_assertions",
- "rustc_version",
+ "rustc_version 0.3.3",
  "serde_json",
  "xz2",
 ]
@@ -269,7 +270,7 @@ checksum = "9c3210a1a81517312746d7ecad5cde4ad9d3ec20640cb6e0c9900c9c6aa6dea1"
 dependencies = [
  "chrono",
  "derive_more",
- "semver",
+ "semver 0.11.0",
  "serde",
 ]
 
@@ -295,6 +296,12 @@ dependencies = [
  "syn",
  "xz2",
 ]
+
+[[package]]
+name = "bumpalo"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
 
 [[package]]
 name = "byte-tools"
@@ -361,7 +368,7 @@ checksum = "081e3f0755c1f380c2d010481b6fa2e02973586d5f2b24eebb7a2a1d98b143d8"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver",
+ "semver 0.11.0",
  "semver-parser",
  "serde",
  "serde_json",
@@ -376,6 +383,15 @@ dependencies = [
  "serde",
  "serde_derive",
  "toml",
+]
+
+[[package]]
+name = "cast"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c24dab4283a142afa2fdca129b80ad2c6284e073930f964c3a1293c225ee39a"
+dependencies = [
+ "rustc_version 0.4.0",
 ]
 
 [[package]]
@@ -602,6 +618,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1604dafd25fba2fe2d5895a9da139f8dc9b319a5fe5354ca137cbbce4e178d10"
+dependencies = [
+ "atty",
+ "cast",
+ "clap",
+ "criterion-plot",
+ "csv",
+ "itertools",
+ "lazy_static",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_cbor",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d00996de9f2f7559f7f4dc286073197f83e92256a59ed395f9aac01fe717da57"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -643,6 +695,28 @@ checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
 dependencies = [
  "cfg-if 1.0.0",
  "lazy_static",
+]
+
+[[package]]
+name = "csv"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
+dependencies = [
+ "bstr",
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -709,7 +783,7 @@ dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "rustc_version",
+ "rustc_version 0.3.3",
  "syn",
 ]
 
@@ -1033,6 +1107,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62aca2aba2d62b4a7f5b33f3712cb1b0692779a56fb510499d5c0aa594daeaf3"
+
+[[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1075,6 +1155,7 @@ dependencies = [
  "chrono",
  "clap",
  "codespan-reporting",
+ "criterion",
  "dirs",
  "env_logger 0.8.4",
  "hotg-rune-codegen",
@@ -1424,6 +1505,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "229d53d58899083193af11e15917b5640cd40b29ff475a1fe4ef725deb02d0f2"
 dependencies = [
  "rayon",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce791b7ca6638aae45be056e068fc756d871eb3b3b10b8efa62d1c9cec616752"
+dependencies = [
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1888,6 +1978,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
+name = "oorandom"
+version = "11.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+
+[[package]]
 name = "opaque-debug"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2028,6 +2124,34 @@ name = "pkg-config"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
+
+[[package]]
+name = "plotters"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a3fd9ec30b9749ce28cd91f255d569591cdf937fe280c312143e3c4bad6f2a"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d88417318da0eaf0fdcdb51a0ee6c3bed624333bff8f946733049380be67ac1c"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521fa9638fa597e1dc53e9412a4f9cefb01187ee1f7413076f9e6749e2885ba9"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "png"
@@ -2434,7 +2558,16 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
 dependencies = [
- "semver",
+ "semver 0.11.0",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver 1.0.4",
 ]
 
 [[package]]
@@ -2513,6 +2646,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
+
+[[package]]
 name = "semver-parser"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2546,6 +2685,16 @@ version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16ae07dd2f88a366f15bd0632ba725227018c69a1c8550a927324f8eb8368bb9"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_cbor"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e18acfa2f90e8b735b2836ab8d538de304cbb6729a7360729ea5a895d15a622"
+dependencies = [
+ "half",
  "serde",
 ]
 
@@ -2803,6 +2952,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2973,6 +3132,60 @@ name = "wasi"
 version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b608ecc8f4198fe8680e2ed18eccab5f0cd4caaf3d83516fa5fb2e927fda2586"
+dependencies = [
+ "cfg-if 1.0.0",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "580aa3a91a63d23aac5b6b267e2d13cb4f363e31dce6c352fca4752ae12e479f"
+dependencies = [
+ "bumpalo",
+ "lazy_static",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171ebf0ed9e1458810dfcb31f2e766ad6b3a89dbda42d8901f2b268277e5f09c"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c2657dd393f03aa2a659c25c6ae18a13a4048cebd220e147933ea837efc589f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e0c4a743a309662d45f4ede961d7afa4ba4131a59a639f29b0069c3798bbcc2"
 
 [[package]]
 name = "wasmer"
@@ -3179,6 +3392,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ab2cc8d9a69d1ab28a41d9149bb06bb927aba8fc9d56625f8b597a564c83f50"
 dependencies = [
  "wast",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01c70a82d842c9979078c772d4a1344685045f1a5628f677c2b2eab4dd7d2696"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/crates/rune-cli/Cargo.toml
+++ b/crates/rune-cli/Cargo.toml
@@ -46,6 +46,7 @@ predicates = "1.0.7"
 tempfile = "3.2.0"
 walkdir = "2.3.2"
 criterion = "0.3"
+tempdir = "0.3"
 
 [build-dependencies]
 build-info-build = "0.0.23"

--- a/crates/rune-cli/Cargo.toml
+++ b/crates/rune-cli/Cargo.toml
@@ -45,6 +45,11 @@ assert_cmd = "1.0.3"
 predicates = "1.0.7"
 tempfile = "3.2.0"
 walkdir = "2.3.2"
+criterion = "0.3"
 
 [build-dependencies]
 build-info-build = "0.0.23"
+
+[[bench]]
+name = "rune_benchmark"
+harness = false

--- a/crates/rune-cli/benches/rune_benchmark.rs
+++ b/crates/rune-cli/benches/rune_benchmark.rs
@@ -79,7 +79,7 @@ fn build_rune(rune_path: &PathBuf, rune_name: String, rune: Rune) {
     let blob = hotg_rune_codegen::generate_with_env(compilation, &mut env)
         .expect("Rune compilation failed");
 
-    assert!(blob.len() != 0);
+    assert_ne!(blob.len(), 0);
 
     rune_build_dir.close().expect("Unable to close the rune build directory");
 }

--- a/crates/rune-cli/benches/rune_benchmark.rs
+++ b/crates/rune-cli/benches/rune_benchmark.rs
@@ -106,9 +106,10 @@ fn microspeech_inference_benchmark(c: &mut Criterion) {
     let base = example_dir().join("microspeech");
 
     let mut img = BaseImage::with_defaults();
+    let wav_file = base.join("data").join("right").join("fb7eb481_nohash_0.wav");
     img.register_capability(
         capabilities::SOUND,
-        new_multiplexer::<Sound, _>(vec![AudioClip::from_wav_file(base.join("data").join("right").join("fb7eb481_nohash_0.wav")).unwrap()]));
+        new_multiplexer::<Sound, _>(vec![AudioClip::from_wav_file(wav_file).unwrap()]));
 
     let mut runtime = Runtime::load(&load_rune(base.join("microspeech.rune")), img)
         .context("Unable to create rune runtime")

--- a/crates/rune-cli/benches/rune_benchmark.rs
+++ b/crates/rune-cli/benches/rune_benchmark.rs
@@ -45,12 +45,12 @@ fn parse_runefile(runefile: &Path) -> Rune {
     rune
 }
 
-fn build_rune(rune_path: PathBuf, rune_name: String, rune: Rune) {
+fn build_rune(rune_path: PathBuf, name: String, rune: Rune) {
     let rune_build_dir = TempDir::new("rune_build_dir").unwrap();
 
     let compilation = Compilation {
-        name: rune_name,
-        rune: rune,
+        name,
+        rune,
         working_directory: rune_build_dir.path().to_path_buf(),
         current_directory: rune_path,
         rune_project: RuneProject::Disk(project_root()),

--- a/crates/rune-cli/benches/rune_benchmark.rs
+++ b/crates/rune-cli/benches/rune_benchmark.rs
@@ -1,0 +1,89 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use std::path::{Path, PathBuf};
+use anyhow::{Context};
+use hotg_rune_cli::run::{
+    Image,
+    image::ImageSource,
+    Sound,
+    sound::AudioClip,
+    new_multiplexer,
+};
+
+use hotg_rune_wasmer_runtime::Runtime;
+use hotg_runicos_base_runtime::BaseImage;
+use hotg_rune_core::capabilities;
+
+// TODO: Refactor this out as this is shared with tests
+pub fn project_root() -> PathBuf {
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .canonicalize()
+        .unwrap();
+
+    for ancestor in manifest_dir.ancestors() {
+        if ancestor.join(".git").is_dir() {
+            return ancestor.to_path_buf();
+        }
+    }
+
+    unreachable!(
+        "Unable to determine the project's root directory. Where is \".git/\"?"
+    );
+}
+
+pub fn example_dir() -> PathBuf { project_root().join("examples") }
+
+fn load_rune(path: PathBuf) -> Vec<u8> {
+    std::fs::read(&path).with_context(|| {
+        format!("Unable to read \"{}\"", path.display())
+    }).unwrap()
+}
+
+fn sine_inference_benchmark(c: &mut Criterion) {
+    let mut runtime = Runtime::load(&load_rune(example_dir().join("sine").join("sine.rune")),
+                                    BaseImage::with_defaults())
+        .context("Unable to create rune runtime")
+        .unwrap();
+
+    c.bench_function("sine_inference",
+        |b| b.iter(|| { runtime.call().context("Call Failed").unwrap() }));
+}
+
+fn microspeech_inference_benchmark(c: &mut Criterion) {
+    let base = example_dir().join("microspeech");
+
+    let mut img = BaseImage::with_defaults();
+    img.register_capability(
+        capabilities::SOUND,
+        new_multiplexer::<Sound, _>(vec![AudioClip::from_wav_file(base.join("data").join("right").join("fb7eb481_nohash_0.wav")).unwrap()]));
+
+    let mut runtime = Runtime::load(&load_rune(base.join("microspeech.rune")), img)
+        .context("Unable to create rune runtime")
+        .unwrap();
+
+    c.bench_function("microspeech_inference",
+        |b| b.iter(|| runtime.call().context("Call Failed").unwrap()));
+}
+
+fn styletransfer_inference_benchmark(c: &mut Criterion) {
+    let base = example_dir().join("style_transfer");
+
+    let mut img = BaseImage::with_defaults();
+    img.register_capability(
+        capabilities::IMAGE,
+        new_multiplexer::<Image, _>(vec![ImageSource::from_file(base.join("style.jpg")).unwrap(),
+                                         ImageSource::from_file(base.join("flower.jpg")).unwrap()]));
+
+    let mut runtime = Runtime::load(&load_rune(base.join("style_transfer.rune")), img)
+        .context("Unable to create rune runtime")
+        .unwrap();
+
+    c.bench_function("styletransfer_inference",
+        |b| b.iter(|| runtime.call().context("Call Failed").unwrap()));
+}
+
+criterion_group!(
+    name = inference_benchmark;
+    config = Criterion::default().significance_level(0.1).sample_size(10);
+    targets = sine_inference_benchmark, microspeech_inference_benchmark, styletransfer_inference_benchmark);
+
+criterion_main!(inference_benchmark);

--- a/crates/rune-cli/benches/rune_benchmark.rs
+++ b/crates/rune-cli/benches/rune_benchmark.rs
@@ -20,21 +20,12 @@ use hotg_rune_codegen::{
 
 use hotg_rune_syntax::{hir::Rune, yaml::Document, Diagnostics};
 
-// TODO: Refactor this out as this is shared with tests
 pub fn project_root() -> PathBuf {
-    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
-        .canonicalize()
-        .unwrap();
-
-    for ancestor in manifest_dir.ancestors() {
-        if ancestor.join(".git").is_dir() {
-            return ancestor.to_path_buf();
-        }
-    }
-
-    unreachable!(
-        "Unable to determine the project's root directory. Where is \".git/\"?"
-    );
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .find(|path| path.join(".git").exists())
+        .expect("Unable to determine the project's root directory. Where is \".git/\"?")
+        .to_path_buf()
 }
 
 pub fn example_dir() -> PathBuf { project_root().join("examples") }

--- a/crates/rune-cli/benches/rune_benchmark.rs
+++ b/crates/rune-cli/benches/rune_benchmark.rs
@@ -80,8 +80,6 @@ fn build_rune(rune_path: &PathBuf, rune_name: String, rune: Rune) {
         .expect("Rune compilation failed");
 
     assert_ne!(blob.len(), 0);
-
-    rune_build_dir.close().expect("Unable to close the rune build directory");
 }
 
 fn sine_build_benchmark(c: &mut Criterion) {

--- a/crates/rune-cli/benches/rune_benchmark.rs
+++ b/crates/rune-cli/benches/rune_benchmark.rs
@@ -77,7 +77,7 @@ fn build_rune(rune_path: &PathBuf, rune_name: String, rune: Rune) {
     let mut env = DefaultEnvironment::for_compilation(&compilation);
 
     let blob = hotg_rune_codegen::generate_with_env(compilation, &mut env)
-        .context("Rune compilation failed").unwrap();
+        .expect("Rune compilation failed");
 
     assert!(blob.len() != 0);
 

--- a/crates/rune-cli/benches/rune_benchmark.rs
+++ b/crates/rune-cli/benches/rune_benchmark.rs
@@ -45,14 +45,14 @@ fn parse_runefile(runefile: &Path) -> Rune {
     rune
 }
 
-fn build_rune(rune_path: &PathBuf, rune_name: String, rune: Rune) {
+fn build_rune(rune_path: PathBuf, rune_name: String, rune: Rune) {
     let rune_build_dir = TempDir::new("rune_build_dir").unwrap();
 
     let compilation = Compilation {
         name: rune_name,
         rune: rune,
         working_directory: rune_build_dir.path().to_path_buf(),
-        current_directory: rune_path.clone(),
+        current_directory: rune_path,
         rune_project: RuneProject::Disk(project_root()),
         optimized: true,
         verbosity: Verbosity::Quiet,
@@ -72,7 +72,7 @@ fn sine_build_benchmark(c: &mut Criterion) {
     let rune = parse_runefile(&runefile);
 
     c.bench_function("sine_build",
-        |b| b.iter(|| { build_rune(&base, String::from("sine"), rune.clone()) }));
+        |b| b.iter(|| { build_rune(base.clone(), String::from("sine"), rune.clone()) }));
 }
 
 fn sine_inference_benchmark(c: &mut Criterion) {

--- a/crates/rune-cli/src/lib.rs
+++ b/crates/rune-cli/src/lib.rs
@@ -2,7 +2,7 @@ mod build;
 mod graph;
 mod inspect;
 mod model_info;
-mod run;
+pub mod run;
 mod version;
 
 use codespan_reporting::term::termcolor;

--- a/crates/rune-cli/src/lib.rs
+++ b/crates/rune-cli/src/lib.rs
@@ -1,4 +1,4 @@
-mod build;
+pub mod build;
 mod graph;
 mod inspect;
 mod model_info;

--- a/crates/rune-cli/src/run/mod.rs
+++ b/crates/rune-cli/src/run/mod.rs
@@ -1,10 +1,10 @@
-mod accelerometer;
-mod command;
-mod image;
+pub mod accelerometer;
+pub mod command;
+pub mod image;
 pub mod multi;
-mod raw;
 mod runecoral_inference;
-mod sound;
+pub mod raw;
+pub mod sound;
 
 use hotg_rune_runtime::ParameterError;
 


### PR DESCRIPTION
We use the criterion benchmark framework for this task, as the built in rust benchmarks aren't yet available in rust stable.
Each of the benchmarks use a sample size of 10 instead of the default 100.

These benchmarks measure the time taken for:

1) build - sine rune
2) inference - sine rune, microspeech, style transfer.

The results on my Linux Ryzen 7 1700 machine look like:

![image](https://user-images.githubusercontent.com/265528/128272112-36d8234f-554f-4e1b-9f55-7cf1ae68f16d.png)


~TODO: Try to enable Github Actions for these benchmarks~ These benchmarks can be run manually before each release, so we aren't adding them to github actions for now