### PR TITLE
Bumped the nightly version because of rust-lang/rust#87877

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2021-08-13"
+channel = "nightly-2021-08-14"
 targets = ["wasm32-unknown-unknown"]
 components = ["rustfmt"]


### PR DESCRIPTION
This should fix an ICE (rust-lang/rust#87877) we found in our nightly releases.