### PR TITLE
wasm3: propagate host errors as WASM abort traps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3154,8 +3154,7 @@ checksum = "2e0c4a743a309662d45f4ede961d7afa4ba4131a59a639f29b0069c3798bbcc2"
 [[package]]
 name = "wasm3"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a139bdde910901a80d0bbe2892fb3206515e5aa926f96c8e5fd0e7bfe35b2c6e"
+source = "git+https://github.com/wasm3/wasm3-rs.git?rev=51829c4985fbd7bcc1b52a289f4359617a258589#51829c4985fbd7bcc1b52a289f4359617a258589"
 dependencies = [
  "cty",
  "wasm3-sys",
@@ -3164,11 +3163,11 @@ dependencies = [
 [[package]]
 name = "wasm3-sys"
 version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed8ddb52050c8cdcf4bc390b053c7031e830354b0cf54c5bdb1ea831c8a7002"
+source = "git+https://github.com/wasm3/wasm3-rs.git?rev=51829c4985fbd7bcc1b52a289f4359617a258589#51829c4985fbd7bcc1b52a289f4359617a258589"
 dependencies = [
  "cc",
  "cty",
+ "shlex 0.1.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ exclude = ["bindings/web"]
 
 [patch.crates-io]
 serde_yaml = { git = "https://github.com/hotg-ai/serde-yaml", branch = "spans" }
+wasm3 = { git = "https://github.com/wasm3/wasm3-rs.git", rev = "51829c4985fbd7bcc1b52a289f4359617a258589" }

--- a/crates/wasm3-runtime/src/lib.rs
+++ b/crates/wasm3-runtime/src/lib.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, Error};
 use hotg_rune_runtime::Image;
 use wasm3::{
     CallContext, Environment, Function, Module, ParsedModule, WasmArgs,
-    WasmType,
+    WasmType, error::Trap,
 };
 
 const STACK_SIZE: u32 = 1024 * 16;
@@ -88,7 +88,8 @@ impl<'m> Registrar<'m> {
     where
         Args: WasmArgs,
         Ret: WasmType,
-        F: for<'cc> FnMut(CallContext<'cc>, Args) -> Ret + 'static,
+        F: for<'cc> FnMut(CallContext<'cc>, Args) -> Result<Ret, Trap>
+            + 'static,
     {
         match self.module.link_closure(namespace, name, f) {
             Ok(()) => {},

--- a/crates/wasm3-runtime/tests/integration.rs
+++ b/crates/wasm3-runtime/tests/integration.rs
@@ -46,6 +46,7 @@ impl Image<Registrar<'_>> for Tracked {
         let calls = self.calls.clone();
         registrar.register_function("env", "tick", move |_, ()| {
             calls.fetch_add(1, Ordering::SeqCst);
+            Ok(())
         });
     }
 }

--- a/images/runicos-base/runtime/src/image/wasm3_impl.rs
+++ b/images/runicos-base/runtime/src/image/wasm3_impl.rs
@@ -1,7 +1,7 @@
 use std::{fmt, marker::PhantomData, mem, slice, str::Utf8Error};
 
 use hotg_rune_runtime::Image;
-use wasm3::CallContext;
+use wasm3::{CallContext, error::Trap};
 use hotg_rune_wasm3_runtime::Registrar;
 
 use super::*;
@@ -143,15 +143,11 @@ impl WasmPtr<u8, Array> {
 
 struct RuntimeError(anyhow::Error);
 
-fn res(res: Result<u32, RuntimeError>) -> u32 {
-    match res {
-        Ok(val) => val,
-        Err(e) => {
-            // TODO figure out how to propagate this
-            log::error!("{}", e.0);
-            u32::MAX
-        },
-    }
+fn res(res: Result<u32, RuntimeError>) -> Result<u32, Trap> {
+    res.map_err(|e| {
+        log::error!("{}", e.0);
+        Trap::Abort
+    })
 }
 
 macro_rules! hostfn_wrappers {
@@ -165,7 +161,7 @@ macro_rules! hostfn_wrappers {
             fn $hostfn_name<Env $(, $name)*>(
                 f: fn(CallContext<'_>, &Env $(, $name)*) -> Result<u32, RuntimeError>,
                 env: Env,
-            ) -> impl FnMut(CallContext<'_>, ($($name,)*)) -> u32 {
+            ) -> impl FnMut(CallContext<'_>, ($($name,)*)) -> Result<u32, Trap> {
                 move |cc, ($($name,)*)| res(f(cc, &env $(, $name)*))
             }
         )+


### PR DESCRIPTION
This uses the functionality added in https://github.com/wasm3/wasm3-rs/commit/51829c4985fbd7bcc1b52a289f4359617a258589 to turn any errors in the Rune WASM runtime into an abort trap on the WASM side. wasm3 does not provide a mechanism for custom errors or error payloads, so errors are still just logged and disposed, but execution of the WASM code will now stop with an abort.

Since this `[patch]`es wasm3-rs to use the git version, this PR should probably be considered blocked until wasm3 0.3 is published with these changes.

Addresses the 3rd point in https://github.com/hotg-ai/rune/issues/241