### PR TITLE
wasm3: enable limited `all_intrinsics_are_registered` test

### DIFF
--- a/crates/wasm3-runtime/src/lib.rs
+++ b/crates/wasm3-runtime/src/lib.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use anyhow::{anyhow, Error};
 use hotg_rune_runtime::Image;
 use wasm3::{
@@ -44,8 +46,10 @@ impl Runtime {
 
         // TODO: Rename the _manifest() method to _start() so it gets
         // automatically invoked while instantiating.
-        let manifest: Function<(), i32> =
-            registrar.module.find_function("_manifest").to_anyhow()?;
+        let manifest: Function<(), i32> = registrar
+            .into_module()
+            .find_function("_manifest")
+            .to_anyhow()?;
         manifest.call().to_anyhow()?;
 
         log::debug!("Loaded the Rune");
@@ -72,12 +76,19 @@ impl Runtime {
     }
 }
 
-pub struct Registrar<'m> {
-    module: Module<'m>,
+pub struct Registrar<'m>(RegistrarInner<'m>);
+
+enum RegistrarInner<'m> {
+    Module(Module<'m>),
+    Tracing(HashSet<(String, String)>),
 }
 
 impl<'m> Registrar<'m> {
-    pub fn new(module: Module<'m>) -> Self { Self { module } }
+    pub fn new(module: Module<'m>) -> Self {
+        Self(RegistrarInner::Module(module))
+    }
+
+    pub fn tracing() -> Self { Self(RegistrarInner::Tracing(HashSet::new())) }
 
     pub fn register_function<Args, Ret, F>(
         &mut self,
@@ -90,20 +101,46 @@ impl<'m> Registrar<'m> {
         Ret: WasmType,
         F: for<'cc> FnMut(CallContext<'cc>, Args) -> Ret + 'static,
     {
-        match self.module.link_closure(namespace, name, f) {
-            Ok(()) => {},
-            Err(wasm3::error::Error::FunctionNotFound) => {
-                // This error occurs when we try to link a function into the
-                // program that the program doesn't import. We
-                // just ignore that error here, since that is fine.
+        match &mut self.0 {
+            RegistrarInner::Module(module) => match module
+                .link_closure(namespace, name, f)
+            {
+                Ok(()) => {},
+                Err(wasm3::error::Error::FunctionNotFound) => {
+                    // This error occurs when we try to link a function into the
+                    // program that the program doesn't import. We
+                    // just ignore that error here, since that is fine.
+                },
+                Err(e) => {
+                    panic!(
+                        "wasm3 register_function failed for `{}::{}`: {}",
+                        namespace, name, e
+                    );
+                },
             },
-            Err(e) => {
-                panic!(
-                    "wasm3 register_function failed for `{}::{}`: {}",
-                    namespace, name, e
-                );
+            RegistrarInner::Tracing(trace) => {
+                trace.insert((namespace.to_string(), name.to_string()));
             },
         }
+
         self
+    }
+
+    pub fn into_module(self) -> Module<'m> {
+        match self.0 {
+            RegistrarInner::Module(m) => m,
+            RegistrarInner::Tracing(_) => {
+                panic!("called `into_module` on tracing registrar")
+            },
+        }
+    }
+
+    pub fn into_trace(self) -> HashSet<(String, String)> {
+        match self.0 {
+            RegistrarInner::Module(_) => {
+                panic!("called `into_trace` on non-tracing registrar")
+            },
+            RegistrarInner::Tracing(trace) => trace,
+        }
     }
 }

--- a/images/runicos-base/runtime/src/image/wasm3_impl.rs
+++ b/images/runicos-base/runtime/src/image/wasm3_impl.rs
@@ -754,7 +754,6 @@ fn debug(
 fn runtime_error(e: Error) -> RuntimeError { RuntimeError(e) }
 
 #[cfg(test)]
-#[cfg(never)] // TODO: port this over (wasm3 lacks reflection though)
 mod tests {
     use syn::{ForeignItem, ForeignItemFn, Item};
     use hotg_rune_wasm3_runtime::Registrar;
@@ -779,29 +778,27 @@ mod tests {
 
     #[test]
     fn all_intrinsics_are_registered() {
-        let store = Store::default();
+        // Unlike the wasmer-version of this test, we don't validate function
+        // signatures here
+        // However, wasm3 already does this when linking functions to a WASM
+        // program that imports them, so this should not cause subtle
+        // bugs in practice (spawning the runtime will just fail).
+
         let intrinsics_rs = include_str!("../../../wasm/src/intrinsics.rs");
         let intrinsics = extern_functions(intrinsics_rs).map(|f| f.sig);
-        let mut registrar = Registrar::new(&store);
+        let mut registrar = Registrar::tracing();
 
         BaseImage::default().initialize_imports(&mut registrar);
 
-        let imports = registrar.into_import_object();
+        let imports = registrar.into_trace();
 
         for intrinsic in intrinsics {
             let name = intrinsic.ident.to_string();
-            let got = imports.get_export("env", &name).expect(&name);
 
-            let got = match got {
-                Export::Function(f) => f,
-                other => panic!("\"{}\" was a {:?}", name, other),
-            };
-            let host_function_signature = &got.vm_function.signature;
-            assert_eq!(
-                intrinsic.inputs.len(),
-                host_function_signature.params().len(),
-                "parameters for \"{}\" are mismatched",
-                name,
+            assert!(
+                imports.contains(&("env".to_string(), name.clone())),
+                "wasm3 API is missing function `{}`",
+                name
             );
         }
     }


### PR DESCRIPTION
This is a reduced version of the wasmer `all_intrinsics_are_registered` test that only checks for presence of all intrinsics, not that their signatures match, since wasm3-rs currently provides no reflection API.