### PR TITLE
wasm3: propagate host errors as WASM abort traps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3155,8 +3155,7 @@ checksum = "2e0c4a743a309662d45f4ede961d7afa4ba4131a59a639f29b0069c3798bbcc2"
 [[package]]
 name = "wasm3"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a139bdde910901a80d0bbe2892fb3206515e5aa926f96c8e5fd0e7bfe35b2c6e"
+source = "git+https://github.com/wasm3/wasm3-rs.git?rev=51829c4985fbd7bcc1b52a289f4359617a258589#51829c4985fbd7bcc1b52a289f4359617a258589"
 dependencies = [
  "cty",
  "wasm3-sys",
@@ -3165,11 +3164,11 @@ dependencies = [
 [[package]]
 name = "wasm3-sys"
 version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed8ddb52050c8cdcf4bc390b053c7031e830354b0cf54c5bdb1ea831c8a7002"
+source = "git+https://github.com/wasm3/wasm3-rs.git?rev=51829c4985fbd7bcc1b52a289f4359617a258589#51829c4985fbd7bcc1b52a289f4359617a258589"
 dependencies = [
  "cc",
  "cty",
+ "shlex 0.1.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ exclude = ["bindings/web"]
 
 [patch.crates-io]
 serde_yaml = { git = "https://github.com/hotg-ai/serde-yaml", branch = "spans" }
+wasm3 = { git = "https://github.com/wasm3/wasm3-rs.git", rev = "51829c4985fbd7bcc1b52a289f4359617a258589" }

--- a/crates/wasm3-runtime/src/lib.rs
+++ b/crates/wasm3-runtime/src/lib.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, Error};
 use hotg_rune_runtime::Image;
 use wasm3::{
     CallContext, Environment, Function, Module, ParsedModule, WasmArgs,
-    WasmType,
+    WasmType, error::Trap,
 };
 
 const STACK_SIZE: u32 = 1024 * 16;
@@ -88,7 +88,8 @@ impl<'m> Registrar<'m> {
     where
         Args: WasmArgs,
         Ret: WasmType,
-        F: for<'cc> FnMut(CallContext<'cc>, Args) -> Ret + 'static,
+        F: for<'cc> FnMut(CallContext<'cc>, Args) -> Result<Ret, Trap>
+            + 'static,
     {
         match self.module.link_closure(namespace, name, f) {
             Ok(()) => {},

--- a/crates/wasm3-runtime/tests/integration.rs
+++ b/crates/wasm3-runtime/tests/integration.rs
@@ -46,6 +46,7 @@ impl Image<Registrar<'_>> for Tracked {
         let calls = self.calls.clone();
         registrar.register_function("env", "tick", move |_, ()| {
             calls.fetch_add(1, Ordering::SeqCst);
+            Ok(())
         });
     }
 }


### PR DESCRIPTION
This is just #275 but with the merge conflicts resolved.