### PR TITLE
Cut the next release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Users of the web runtime are now able to provide custom model handlers
   (e.g. if you want to use your own ML framework)
+- Added "Resources" to the Runefile
+  ([#273](https://github.com/hotg-ai/rune/pull/273),
+  [#285](https://github.com/hotg-ai/rune/pull/285))
+  - Resources can be loaded from disk using the `path: ./some/file.ext` syntax
+  - Resources can also be specified in the Runefile itself using the
+    `inline: "value"` syntax
+  - A model can be bound to a resource using `model: $MY_MODEL`
+  - Procedure block arguments can be set using `some_arg: $VALUE`
+  - A resource can be overridden at runtime using a different version
+  - The `rune` CLI can override resources with `--resource-file NAME=./file.ext`
+    or `--resource-string NAME=value`
+- We now fall back to using WASM3 to evaluate WebAssembly code on platforms not
+  supported by Wasmer, primarily iOS
+  ([#266](https://github.com/hotg-ai/rune/pull/266),
+  [#267](https://github.com/hotg-ai/rune/pull/267),
+  [#271](https://github.com/hotg-ai/rune/pull/271),
+  [#280](https://github.com/hotg-ai/rune/pull/280),
+  [#281](https://github.com/hotg-ai/rune/pull/281))
+- Gave the web runtime a builder type to simplify the process of initializing
+  and loading Runes ([#279](https://github.com/hotg-ai/rune/pull/279))
+
+### Fixed
+
+- Resolved an issue where `cargo install hotg-rune-cli` would fail due to an
+  accidental backwards incompatible change in the `cargo_toml` crate
+  ([#284](https://github.com/hotg-ai/rune/issues/284))
 
 ## [0.6.0] - 2021-08-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+## [0.7.0] - 2021-09-07
+
 ### Added
 
 - Users of the web runtime are now able to provide custom model handlers
@@ -161,7 +163,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.2.1] - 2021-03-21
 
 <!-- next-url -->
-[Unreleased]: https://github.com/assert-rs/predicates-rs/compare/hotg-rune-cli-v0.6.0...HEAD
+[Unreleased]: https://github.com/assert-rs/predicates-rs/compare/hotg-rune-cli-v0.7.0...HEAD
+[0.7.0]: https://github.com/assert-rs/predicates-rs/compare/hotg-rune-cli-v0.6.0...hotg-rune-cli-v0.7.0
 [0.6.0]: https://github.com/assert-rs/predicates-rs/compare/hotg-rune-cli-v0.5.3...hotg-rune-cli-v0.6.0
 [0.5.3]: https://github.com/assert-rs/predicates-rs/compare/hotg-rune-cli-v0.5.2...hotg-rune-cli-v0.5.3
 [0.5.2]: https://github.com/assert-rs/predicates-rs/compare/v0.4.0...hotg-rune-cli-v0.5.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,9 +52,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.42"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595d3cfa7a60d4555cb5067b99f07142a08ea778de5cf993f7b75c7d8fabc486"
+checksum = "28ae2b3dec75a406790005a200b1bd89785afc02517a00ca99ecfe093ee9e6cf"
 
 [[package]]
 name = "apodize"
@@ -66,22 +66,22 @@ dependencies = [
 
 [[package]]
 name = "approx"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f2a05fd1bd10b2527e20a2cd32d8873d115b8b39fe219ee25f42a8aca6ba278"
+checksum = "072df7202e63b127ab55acfe16ce97013d5b97bf160489336d3f1840fd78e99e"
 dependencies = [
  "num-traits",
 ]
 
 [[package]]
 name = "assert_cmd"
-version = "1.0.8"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c98233c6673d8601ab23e77eb38f999c51100d46c5703b17288c57fddf3a1ffe"
+checksum = "b800c4403e8105d959595e1f88119e78bc12bc874c4336973658b648a746ba93"
 dependencies = [
  "bstr",
  "doc-comment",
- "predicates 2.0.1",
+ "predicates",
  "predicates-core",
  "predicates-tree",
  "wait-timeout",
@@ -124,7 +124,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "miniz_oxide 0.4.4",
- "object 0.26.0",
+ "object 0.26.2",
  "rustc-demangle",
 ]
 
@@ -186,15 +186,15 @@ dependencies = [
  "quote",
  "regex",
  "rustc-hash",
- "shlex 1.0.0",
+ "shlex 1.1.0",
  "which 3.1.1",
 ]
 
 [[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bstr"
@@ -210,9 +210,9 @@ dependencies = [
 
 [[package]]
 name = "build-info"
-version = "0.0.23"
+version = "0.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "569d94157949b69d52fd80b77a33cffa083ebcd7abf6d60999b41cc977664a32"
+checksum = "19fbbf442dbe14f0cbc09b8dcf9ccf32537390fb25ea717430d3a18508c66c66"
 dependencies = [
  "build-info-common",
  "build-info-proc",
@@ -222,9 +222,9 @@ dependencies = [
 
 [[package]]
 name = "build-info-build"
-version = "0.0.23"
+version = "0.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7975fa865b3562339bdec59ee877d2a8618c4f95dc0e4729f3d501818cae11b1"
+checksum = "c73c69ee8cdfec986e4827238488746f472a8d1dda9423ea113064fc33f1419c"
 dependencies = [
  "anyhow",
  "base64",
@@ -236,28 +236,28 @@ dependencies = [
  "glob",
  "lazy_static",
  "pretty_assertions",
- "rustc_version 0.3.3",
+ "rustc_version 0.4.0",
  "serde_json",
  "xz2",
 ]
 
 [[package]]
 name = "build-info-common"
-version = "0.0.23"
+version = "0.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3210a1a81517312746d7ecad5cde4ad9d3ec20640cb6e0c9900c9c6aa6dea1"
+checksum = "c1a56f0765f909b7b4d7d5c7833e6c66bc1f63dab8046adc8effd568d676cd04"
 dependencies = [
  "chrono",
  "derive_more",
- "semver 0.11.0",
+ "semver 1.0.4",
  "serde",
 ]
 
 [[package]]
 name = "build-info-proc"
-version = "0.0.23"
+version = "0.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22b0c07441c4c64c569cbf637e1e181b1c9c934764c7dcaac0ab7d8ffc8e1eba"
+checksum = "62b85100fe8843c08f07f9065e3c6fd4a5dce6d13b953307faa98b7b5e1ea804"
 dependencies = [
  "anyhow",
  "base64",
@@ -369,9 +369,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.69"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e70cc2f62c6ce1868963827bd677764c62d07c3d9a3e1fb1177ee1a9ab199eb2"
+checksum = "d26a6ce4b6a484fa3edb70f7efa6fc430fd2b87285fe8b84304fd0936faa0dc0"
 dependencies = [
  "jobserver",
 ]
@@ -413,9 +413,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.2.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "853eda514c284c2287f4bf20ae614f8781f40a81d32ecda6e91449304dfe077c"
+checksum = "10612c0ec0e0a1ff0e97980647cb058a6e7aedb913d01d009c406b8b7d0b26ee"
 dependencies = [
  "glob",
  "libc",
@@ -694,9 +694,9 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e98e2ad1a782e33928b96fc3948e7c355e5af34ba4de7670fe8bac2a3b2006d"
+checksum = "ccc0a48a9b826acdf4028595adc9db92caea352f7af011a3034acd172a52a0aa"
 dependencies = [
  "quote",
  "syn",
@@ -899,6 +899,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
+dependencies = [
+ "atty",
+ "humantime 2.1.0",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -920,16 +933,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "fixedbitset"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
-
-[[package]]
 name = "flate2"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd3aec53de10fe96d7d8c565eb17f2c687bb5518a2ec453b5b1252964526abe0"
+checksum = "80edafed416a46fb378521624fab1cfa2eb514784fd8921adbe8a8d8321da811"
 dependencies = [
  "cfg-if 1.0.0",
  "crc32fast",
@@ -939,9 +946,9 @@ dependencies = [
 
 [[package]]
 name = "float-cmp"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1267f4ac4f343772758f7b1bdcbe767c218bbab93bb432acbf5162bbf85a6c4"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
 dependencies = [
  "num-traits",
 ]
@@ -1037,9 +1044,9 @@ checksum = "f0a01e0497841a3b2db4f8afa483cce65f7e96a3498bd6c541734792aeac8fe7"
 
 [[package]]
 name = "git2"
-version = "0.13.20"
+version = "0.13.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9831e983241f8c5591ed53f17d874833e2fa82cac2625f3888c50cbfe136cba"
+checksum = "659cd14835e75b64d9dba5b660463506763cf0aa6cb640aeeb0e98d841093490"
 dependencies = [
  "bitflags",
  "libc",
@@ -1114,11 +1121,10 @@ dependencies = [
  "build-info",
  "build-info-build",
  "chrono",
- "clap",
  "codespan-reporting",
  "criterion",
  "dirs",
- "env_logger 0.8.4",
+ "env_logger 0.9.0",
  "hotg-rune-codegen",
  "hotg-rune-core",
  "hotg-rune-runtime",
@@ -1132,8 +1138,7 @@ dependencies = [
  "indexmap",
  "log",
  "once_cell",
- "petgraph",
- "predicates 1.0.8",
+ "predicates",
  "rand 0.8.4",
  "regex",
  "serde",
@@ -1144,7 +1149,7 @@ dependencies = [
  "tempfile",
  "tflite",
  "walkdir",
- "wasmparser",
+ "wasmparser 0.80.1",
 ]
 
 [[package]]
@@ -1180,7 +1185,7 @@ name = "hotg-rune-integration-tests"
 version = "0.6.1-dev"
 dependencies = [
  "anyhow",
- "env_logger 0.8.4",
+ "env_logger 0.9.0",
  "log",
  "once_cell",
  "regex",
@@ -1472,15 +1477,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
+checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "jobserver"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5ca711fd837261e14ec9e674f092cbb931d3fa1482b017ae59328ddc6f3212b"
+checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
 dependencies = [
  "libc",
 ]
@@ -1496,9 +1501,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.52"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce791b7ca6638aae45be056e068fc756d871eb3b3b10b8efa62d1c9cec616752"
+checksum = "e4bf49d50e2961077d9c99f4b7997d770a1114f087c3c2e0069b36c13fc2979d"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1531,15 +1536,15 @@ checksum = "3576a87f2ba00f6f106fdfcd16db1d698d648a26ad8e0573cad8537c3c362d2a"
 
 [[package]]
 name = "libc"
-version = "0.2.98"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
+checksum = "3cb00336871be5ed2c8ed44b60ae9959dc5b9f08539422ed43f09e34ecaeba21"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.12.21+1.1.0"
+version = "0.12.22+1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86271bacd72b2b9e854c3dcfb82efd538f15f870e4c11af66900effb462f6825"
+checksum = "89c53ac117c44f7042ad8d8f5681378dfbc6010e49ec2c0d1f11dfedc7a4a1c3"
 dependencies = [
  "cc",
  "libc",
@@ -1583,9 +1588,9 @@ checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "lock_api"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0382880606dff6d15c9476c416d18690b72742aa7b605bb6dd6ec9030fbf07eb"
+checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
 dependencies = [
  "scopeguard",
 ]
@@ -1643,9 +1648,9 @@ dependencies = [
 
 [[package]]
 name = "matches"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
+checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "matrixmultiply"
@@ -1675,9 +1680,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "memmap2"
@@ -1755,13 +1760,13 @@ dependencies = [
 
 [[package]]
 name = "nalgebra"
-version = "0.26.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "476d1d59fe02fe54c86356e91650cd892f392782a1cb9fc524ec84f7aa9e1d06"
+checksum = "d506eb7e08d6329505faa8a3a00a5dcc6de9f76e0c77e4b75763ae3c770831ff"
 dependencies = [
  "approx",
- "num-complex 0.3.1",
- "num-rational 0.3.2",
+ "num-complex",
+ "num-rational 0.4.0",
  "num-traits",
  "simba",
  "typenum",
@@ -1774,7 +1779,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08e854964160a323e65baa19a0b1a027f76d590faba01f05c0cbc3187221a8c9"
 dependencies = [
  "matrixmultiply",
- "num-complex 0.4.0",
+ "num-complex",
  "num-integer",
  "num-traits",
  "rawpointer",
@@ -1819,7 +1824,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
 dependencies = [
- "num-complex 0.4.0",
+ "num-complex",
  "num-integer",
  "num-iter",
  "num-rational 0.4.0",
@@ -1828,21 +1833,12 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e0d047c1062aa51e256408c560894e5251f08925980e53cf1aa5bd00eec6512"
+checksum = "74e768dff5fb39a41b3bcd30bb25cf989706c90d028d1ad71971987aa309d535"
 dependencies = [
  "autocfg",
  "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "747d632c0c558b87dbabbe6a82f3b4ae03720d0646ac5b7b4dae89394be5f2c5"
-dependencies = [
  "num-traits",
 ]
 
@@ -1920,14 +1916,14 @@ dependencies = [
 
 [[package]]
 name = "numpy"
-version = "0.13.2"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a996bcd58fb29bef9debf717330cd8876c3b4adbeea4939020a5326a3afad4d9"
+checksum = "09c15af63aa0c74e0f7230d4e95d9a3d71a23449905f30f50b055df9a6a6a3e6"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
  "ndarray",
- "num-complex 0.4.0",
+ "num-complex",
  "num-traits",
  "pyo3",
 ]
@@ -1945,9 +1941,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.26.0"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c55827317fb4c08822499848a14237d2874d6f139828893017237e7ab93eb386"
+checksum = "39f37e50073ccad23b6d09bcb5b263f4e76d3bb6038e4a3c08e52162ffa8abc2"
 dependencies = [
  "memchr",
 ]
@@ -1975,9 +1971,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
@@ -1986,9 +1982,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018"
+checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
 dependencies = [
  "cfg-if 1.0.0",
  "instant",
@@ -2042,16 +2038,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
 dependencies = [
  "ucd-trie",
-]
-
-[[package]]
-name = "petgraph"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
-dependencies = [
- "fixedbitset",
- "indexmap",
 ]
 
 [[package]]
@@ -2114,26 +2100,16 @@ checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "predicates"
-version = "1.0.8"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49cfaf7fdaa3bfacc6fa3e7054e65148878354a5cfddcf661df4c851f8021df"
+checksum = "c143348f141cc87aab5b950021bac6145d0e5ae754b0591de23244cee42c9308"
 dependencies = [
- "difference",
+ "difflib",
  "float-cmp",
+ "itertools",
  "normalize-line-endings",
  "predicates-core",
  "regex",
-]
-
-[[package]]
-name = "predicates"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc3d91237f5de3bcd9d927e24d03b495adb6135097b001cea7403e2d573d00a9"
-dependencies = [
- "difflib",
- "itertools",
- "predicates-core",
 ]
 
 [[package]]
@@ -2196,9 +2172,9 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.28"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
+checksum = "b9f5105d4fdaab20335ca9565e106a5d9b82b6219b5ba735731124ac6711d23d"
 dependencies = [
  "unicode-xid",
 ]
@@ -2225,26 +2201,34 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.13.2"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4837b8e8e18a102c23f79d1e9a110b597ea3b684c95e874eb1ad88f8683109c3"
+checksum = "35100f9347670a566a67aa623369293703322bb9db77d99d7df7313b575ae0c8"
 dependencies = [
  "cfg-if 1.0.0",
- "ctor",
  "indoc",
- "inventory",
  "libc",
  "parking_lot",
  "paste 0.1.18",
+ "pyo3-build-config",
  "pyo3-macros",
  "unindent",
 ]
 
 [[package]]
-name = "pyo3-macros"
-version = "0.13.2"
+name = "pyo3-build-config"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47f2c300ceec3e58064fd5f8f5b61230f2ffd64bde4970c81fdd0563a2db1bb"
+checksum = "d12961738cacbd7f91b7c43bc25cfeeaa2698ad07a04b3be0aa88b950865738f"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "pyo3-macros"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0bc5215d704824dfddddc03f93cb572e1155c68b6761c37005e1c288808ea8"
 dependencies = [
  "pyo3-macros-backend",
  "quote",
@@ -2253,11 +2237,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.13.2"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87b097e5d84fcbe3e167f400fbedd657820a375b034c78bd852050749a575d66"
+checksum = "71623fc593224afaab918aa3afcaf86ed2f43d34f6afde7f3922608f253240df"
 dependencies = [
  "proc-macro2",
+ "pyo3-build-config",
  "quote",
  "syn",
 ]
@@ -2387,9 +2372,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ab49abadf3f9e1c4bc499e8845e152ad87d2ad2d30371841171169e9d75feee"
+checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
 dependencies = [
  "bitflags",
 ]
@@ -2510,9 +2495,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dead70b0b5e03e9c814bcb6b01e03e68f7c57a80aa48c72ec92152ab3e818d49"
+checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
 name = "rustc-hash"
@@ -2618,6 +2603,9 @@ name = "semver"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "semver-parser"
@@ -2630,9 +2618,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.127"
+version = "1.0.130"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f03b9878abf6d14e6779d3f24f07b2cfa90352cfec4acc5aab8f1ac7f146fae8"
+checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
 dependencies = [
  "serde_derive",
 ]
@@ -2658,9 +2646,9 @@ dependencies = [
 
 [[package]]
 name = "serde_cbor"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e18acfa2f90e8b735b2836ab8d538de304cbb6729a7360729ea5a895d15a622"
+checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
 dependencies = [
  "half",
  "serde",
@@ -2668,9 +2656,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.127"
+version = "1.0.130"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a024926d3432516606328597e0f224a51355a493b49fdd67e9209187cbe55ecc"
+checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2679,9 +2667,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.66"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "336b10da19a12ad094b59d870ebde26a45402e5b470add4b5fd03c5048a32127"
+checksum = "a7f9e390c27c3c0ce8bc5d725f6e4d30a29d26659494aa4b17535f7522c5c950"
 dependencies = [
  "itoa",
  "ryu",
@@ -2690,11 +2678,12 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.17"
-source = "git+https://github.com/hotg-ai/serde-yaml?branch=spans#6f6bb2d09f5d068e741a58d34f8c9b45e0191b14"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad104641f3c958dab30eb3010e834c2622d1f3f4c530fef1dee20ad9485f3c09"
 dependencies = [
  "dtoa",
- "linked-hash-map",
+ "indexmap",
  "serde",
  "yaml-rust",
 ]
@@ -2707,18 +2696,18 @@ checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 
 [[package]]
 name = "shlex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a568c8f2cd051a4d283bd6eb0343ac214c1b0f1ac19f93e1175b2dee38c73d"
+checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "simba"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5132a955559188f3d13c9ba831e77c802ddc8782783f050ed0c52f5988b95f4c"
+checksum = "f0b7840f121a46d63066ee7a99fc81dcabbc6105e437cae43528cea199b5a05f"
 dependencies = [
  "approx",
- "num-complex 0.3.1",
+ "num-complex",
  "num-traits",
  "paste 1.0.5",
 ]
@@ -2758,9 +2747,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "structopt"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69b041cdcb67226aca307e6e7be44c8806423d83e018bd662360a93dabce4d71"
+checksum = "bf9d950ef167e25e0bdb073cf1d68e9ad2795ac826f2f3f59647817cf23c0bfa"
 dependencies = [
  "clap",
  "lazy_static",
@@ -2769,9 +2758,9 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7813934aecf5f51a54775e00068c237de98489463968231a51746bbbc03f9c10"
+checksum = "134d838a2c9943ac3125cf6df165eda53493451b719f3255b2a26b85f772d0ba"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -2782,18 +2771,18 @@ dependencies = [
 
 [[package]]
 name = "strum"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7318c509b5ba57f18533982607f24070a55d353e90d4cae30c467cdb2ad5ac5c"
+checksum = "aaf86bbcfd1fa9670b7a129f64fc0c9fcbbfe4f1bc4210e9e98fe71ffc12cde2"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.20.1"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee8bc6b87a5112aeeab1f4a9f7ab634fe6cbefc4850006df31267f4cfb9e3149"
+checksum = "d06aaeeee809dbc59eb4556183dd927df67db1540de5be8d3ec0b6636358a5ec"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2803,9 +2792,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.74"
+version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1873d832550d4588c3dbc20f01361ab00bfe741048f71e3fecf145a7cc18b29c"
+checksum = "c6f107db402c2c2055242dbf4d2af0e69197202e9faacbef9571bbe47f5a1b84"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2814,9 +2803,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0652da4c4121005e9ed22b79f6c5f2d9e2752906b53a33e9490489ba421a6fb"
+checksum = "d9bffcddbc2458fa3e6058414599e3c838a022abae82e5c67b4f7f80298d5bff"
 
 [[package]]
 name = "tempdir"
@@ -2877,18 +2866,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.26"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93119e4feac1cbe6c798c34d3a53ea0026b0b1de6a120deef895137c0529bfe2"
+checksum = "602eca064b2d83369e2b2f34b09c70b605402801927c65c11071ac911d299b88"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.26"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "060d69a0afe7796bf42e9e2ff91f5ee691fb15c53d38b4b62a9a53eb23164745"
+checksum = "bad553cc2c78e8de258400763a647e80e6d1b31ee237275d756f6836d204494c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2976,9 +2965,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9ff14f98b1a4b289c6248a023c1c2fa1491062964e9fed67ab29c4e4da4a052"
+checksum = "2ca517f43f0fb96e0c3072ed5c275fe5eece87e8cb52f4a77b69226d3b1c9df8"
 dependencies = [
  "lazy_static",
 ]
@@ -2991,9 +2980,9 @@ checksum = "a7f741b240f1a48843f9b8e0444fb55fb2a4ff67293b50a9179dfd5ea67f8d41"
 
 [[package]]
 name = "typenum"
-version = "1.13.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
+checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
 
 [[package]]
 name = "ucd-trie"
@@ -3003,12 +2992,9 @@ checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeb8be209bb1c96b7c177c7420d26e04eccacb0eeae6b980e35fcb74678107e0"
-dependencies = [
- "matches",
-]
+checksum = "246f4c42e67e7a4e3c6106ff716a5d067d4132a642840b242e357e468a2a0085"
 
 [[package]]
 name = "unicode-normalization"
@@ -3101,9 +3087,9 @@ checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.75"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b608ecc8f4198fe8680e2ed18eccab5f0cd4caaf3d83516fa5fb2e927fda2586"
+checksum = "8ce9b1b516211d33767048e5d47fa2a381ed8b76fc48d2ce4aa39877f9f183e0"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -3111,9 +3097,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.75"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "580aa3a91a63d23aac5b6b267e2d13cb4f363e31dce6c352fca4752ae12e479f"
+checksum = "cfe8dc78e2326ba5f845f4b5bf548401604fa20b1dd1d365fb73b6c1d6364041"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -3126,9 +3112,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.75"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171ebf0ed9e1458810dfcb31f2e766ad6b3a89dbda42d8901f2b268277e5f09c"
+checksum = "44468aa53335841d9d6b6c023eaab07c0cd4bddbcfdee3e2bb1e8d2cb8069fef"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3136,9 +3122,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.75"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c2657dd393f03aa2a659c25c6ae18a13a4048cebd220e147933ea837efc589f"
+checksum = "0195807922713af1e67dc66132c7328206ed9766af3858164fb583eedc25fbad"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3149,14 +3135,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.75"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e0c4a743a309662d45f4ede961d7afa4ba4131a59a639f29b0069c3798bbcc2"
+checksum = "acdb075a845574a1fa5f09fd77e43f7747599301ea3417a9fbffdeedfc1f4a29"
 
 [[package]]
 name = "wasm3"
-version = "0.2.0"
-source = "git+https://github.com/wasm3/wasm3-rs.git?rev=51829c4985fbd7bcc1b52a289f4359617a258589#51829c4985fbd7bcc1b52a289f4359617a258589"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "170fc767bb584a3871e1bfe935a689446cbeef99d07255132ed551b6665ae3f3"
 dependencies = [
  "cty",
  "wasm3-sys",
@@ -3165,11 +3152,11 @@ dependencies = [
 [[package]]
 name = "wasm3-sys"
 version = "0.1.2"
-source = "git+https://github.com/wasm3/wasm3-rs.git?rev=51829c4985fbd7bcc1b52a289f4359617a258589#51829c4985fbd7bcc1b52a289f4359617a258589"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed8ddb52050c8cdcf4bc390b053c7031e830354b0cf54c5bdb1ea831c8a7002"
 dependencies = [
  "cc",
  "cty",
- "shlex 0.1.1",
 ]
 
 [[package]]
@@ -3212,7 +3199,7 @@ dependencies = [
  "thiserror",
  "wasmer-types",
  "wasmer-vm",
- "wasmparser",
+ "wasmparser 0.78.2",
 ]
 
 [[package]]
@@ -3362,28 +3349,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52144d4c78e5cf8b055ceab8e5fa22814ce4315d6002ad32cfd914f37c12fd65"
 
 [[package]]
-name = "wast"
-version = "37.0.0"
+name = "wasmparser"
+version = "0.80.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bc7b9a76845047ded00e031754ff410afee0d50fbdf62b55bdeecd245063d68"
+checksum = "be92b6dcaa5af4b2a176b29be3bf1402fab9e69d313141185099c7d1684f2dca"
+
+[[package]]
+name = "wast"
+version = "38.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ebc29df4629f497e0893aacd40f13a4a56b85ef6eb4ab6d603f07244f1a7bf2"
 dependencies = [
  "leb128",
 ]
 
 [[package]]
 name = "wat"
-version = "1.0.39"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2cc8d9a69d1ab28a41d9149bb06bb927aba8fc9d56625f8b597a564c83f50"
+checksum = "adcfaeb27e2578d2c6271a45609f4a055e6d7ba3a12eff35b1fd5ba147bdf046"
 dependencies = [
  "wast",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.52"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01c70a82d842c9979078c772d4a1344685045f1a5628f677c2b2eab4dd7d2696"
+checksum = "224b2f6b67919060055ef1a67807367c2066ed520c3862cc013d26cf893a783c"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3454,7 +3447,7 @@ dependencies = [
  "cargo_toml",
  "codespan-reporting",
  "devx-pre-commit",
- "env_logger 0.8.4",
+ "env_logger 0.9.0",
  "globset",
  "hotg-rune-syntax",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,7 +100,7 @@ dependencies = [
 
 [[package]]
 name = "audio_float_conversion"
-version = "0.6.1-dev"
+version = "0.7.0"
 dependencies = [
  "hotg-rune-core",
  "hotg-rune-proc-blocks",
@@ -899,7 +899,7 @@ checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fft"
-version = "0.6.1-dev"
+version = "0.7.0"
 dependencies = [
  "hotg-rune-core",
  "hotg-rune-proc-blocks",
@@ -1088,7 +1088,7 @@ dependencies = [
 
 [[package]]
 name = "hotg-rune-cli"
-version = "0.6.1-dev"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1128,7 +1128,7 @@ dependencies = [
 
 [[package]]
 name = "hotg-rune-codegen"
-version = "0.6.1-dev"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "build-info",
@@ -1148,7 +1148,7 @@ dependencies = [
 
 [[package]]
 name = "hotg-rune-core"
-version = "0.6.1-dev"
+version = "0.7.0"
 dependencies = [
  "log",
  "serde",
@@ -1156,7 +1156,7 @@ dependencies = [
 
 [[package]]
 name = "hotg-rune-integration-tests"
-version = "0.6.1-dev"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "env_logger 0.9.0",
@@ -1169,7 +1169,7 @@ dependencies = [
 
 [[package]]
 name = "hotg-rune-native"
-version = "0.6.1-dev"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "build-info",
@@ -1186,7 +1186,7 @@ dependencies = [
 
 [[package]]
 name = "hotg-rune-proc-block-macros"
-version = "0.6.1-dev"
+version = "0.7.0"
 dependencies = [
  "difference",
  "hotg-rune-core",
@@ -1201,7 +1201,7 @@ dependencies = [
 
 [[package]]
 name = "hotg-rune-proc-blocks"
-version = "0.6.1-dev"
+version = "0.7.0"
 dependencies = [
  "hotg-rune-core",
  "hotg-rune-proc-block-macros",
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "hotg-rune-runtime"
-version = "0.6.1-dev"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "hotg-rune-core",
@@ -1223,7 +1223,7 @@ dependencies = [
 
 [[package]]
 name = "hotg-rune-syntax"
-version = "0.6.1-dev"
+version = "0.7.0"
 dependencies = [
  "codespan",
  "codespan-reporting",
@@ -1237,7 +1237,7 @@ dependencies = [
 
 [[package]]
 name = "hotg-rune-wasm3-runtime"
-version = "0.6.1-dev"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "hotg-rune-core",
@@ -1249,7 +1249,7 @@ dependencies = [
 
 [[package]]
 name = "hotg-rune-wasmer-runtime"
-version = "0.6.1-dev"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "hotg-rune-core",
@@ -1274,7 +1274,7 @@ dependencies = [
 
 [[package]]
 name = "hotg-runicos-base-runtime"
-version = "0.6.1-dev"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "hotg-rune-core",
@@ -1293,7 +1293,7 @@ dependencies = [
 
 [[package]]
 name = "hotg-runicos-base-wasm"
-version = "0.6.1-dev"
+version = "0.7.0"
 dependencies = [
  "dlmalloc",
  "hotg-rune-core",
@@ -1368,7 +1368,7 @@ dependencies = [
 
 [[package]]
 name = "image-normalization"
-version = "0.6.1-dev"
+version = "0.7.0"
 dependencies = [
  "hotg-rune-core",
  "hotg-rune-proc-blocks",
@@ -1484,7 +1484,7 @@ dependencies = [
 
 [[package]]
 name = "label"
-version = "0.6.1-dev"
+version = "0.7.0"
 dependencies = [
  "hotg-rune-core",
  "hotg-rune-proc-blocks",
@@ -1712,7 +1712,7 @@ dependencies = [
 
 [[package]]
 name = "modulo"
-version = "0.6.1-dev"
+version = "0.7.0"
 dependencies = [
  "hotg-rune-proc-blocks",
  "num-traits",
@@ -1726,7 +1726,7 @@ checksum = "0debeb9fcf88823ea64d64e4a815ab1643f33127d995978e099942ce38f25238"
 
 [[package]]
 name = "most_confident_indices"
-version = "0.6.1-dev"
+version = "0.7.0"
 dependencies = [
  "hotg-rune-core",
  "hotg-rune-proc-blocks",
@@ -1761,7 +1761,7 @@ dependencies = [
 
 [[package]]
 name = "noise-filtering"
-version = "0.6.1-dev"
+version = "0.7.0"
 dependencies = [
  "hotg-rune-core",
  "hotg-rune-proc-blocks",
@@ -1781,7 +1781,7 @@ dependencies = [
 
 [[package]]
 name = "normalize"
-version = "0.6.1-dev"
+version = "0.7.0"
 dependencies = [
  "hotg-rune-proc-blocks",
 ]
@@ -2455,7 +2455,7 @@ dependencies = [
 
 [[package]]
 name = "rune_py"
-version = "0.6.1-dev"
+version = "0.7.0"
 dependencies = [
  "fft",
  "hotg-rune-core",
@@ -3416,7 +3416,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "xtask"
-version = "0.1.1-dev"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "cargo_toml",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -349,9 +349,9 @@ dependencies = [
 
 [[package]]
 name = "cargo_toml"
-version = "0.9.2"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3596addfb02dcdc06f5252ddda9f3785f9230f5827fb4284645240fa05ad92"
+checksum = "067a0b9ae9282dd1f63b6c1e76a065d741fc1733e566dc50b5b5d8a84d7e3c4a"
 dependencies = [
  "serde",
  "serde_derive",
@@ -767,26 +767,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "devx-cmd"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "771d86e03f7f740de595375e9fb2d39e527868c57e5642e6f4f7a10e2a02a2e2"
-dependencies = [
- "log",
-]
-
-[[package]]
-name = "devx-pre-commit"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f230e4d04e6464a4ddfc854a30a60c430791f876a6564317e9d218daade6b8d9"
-dependencies = [
- "anyhow",
- "devx-cmd",
- "fs-err",
-]
-
-[[package]]
 name = "diff"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -974,12 +954,6 @@ name = "format-buf"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7aea5a5909a74969507051a3b17adc84737e31a5f910559892aedce026f4d53"
-
-[[package]]
-name = "fs-err"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ebd3504ad6116843b8375ad70df74e7bfe83cac77a1f3fe73200c844d43bfe0"
 
 [[package]]
 name = "fs_extra"
@@ -2207,6 +2181,7 @@ checksum = "35100f9347670a566a67aa623369293703322bb9db77d99d7df7313b575ae0c8"
 dependencies = [
  "cfg-if 1.0.0",
  "indoc",
+ "inventory",
  "libc",
  "parking_lot",
  "paste 0.1.18",
@@ -3446,7 +3421,6 @@ dependencies = [
  "anyhow",
  "cargo_toml",
  "codespan-reporting",
- "devx-pre-commit",
  "env_logger 0.9.0",
  "globset",
  "hotg-rune-syntax",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,7 +100,7 @@ dependencies = [
 
 [[package]]
 name = "audio_float_conversion"
-version = "0.7.0"
+version = "0.7.1-dev"
 dependencies = [
  "hotg-rune-core",
  "hotg-rune-proc-blocks",
@@ -899,7 +899,7 @@ checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fft"
-version = "0.7.0"
+version = "0.7.1-dev"
 dependencies = [
  "hotg-rune-core",
  "hotg-rune-proc-blocks",
@@ -1088,7 +1088,7 @@ dependencies = [
 
 [[package]]
 name = "hotg-rune-cli"
-version = "0.7.0"
+version = "0.7.1-dev"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1128,7 +1128,7 @@ dependencies = [
 
 [[package]]
 name = "hotg-rune-codegen"
-version = "0.7.0"
+version = "0.7.1-dev"
 dependencies = [
  "anyhow",
  "build-info",
@@ -1148,7 +1148,7 @@ dependencies = [
 
 [[package]]
 name = "hotg-rune-core"
-version = "0.7.0"
+version = "0.7.1-dev"
 dependencies = [
  "log",
  "serde",
@@ -1156,7 +1156,7 @@ dependencies = [
 
 [[package]]
 name = "hotg-rune-integration-tests"
-version = "0.7.0"
+version = "0.7.1-dev"
 dependencies = [
  "anyhow",
  "env_logger 0.9.0",
@@ -1169,7 +1169,7 @@ dependencies = [
 
 [[package]]
 name = "hotg-rune-native"
-version = "0.7.0"
+version = "0.7.1-dev"
 dependencies = [
  "anyhow",
  "build-info",
@@ -1186,7 +1186,7 @@ dependencies = [
 
 [[package]]
 name = "hotg-rune-proc-block-macros"
-version = "0.7.0"
+version = "0.7.1-dev"
 dependencies = [
  "difference",
  "hotg-rune-core",
@@ -1201,7 +1201,7 @@ dependencies = [
 
 [[package]]
 name = "hotg-rune-proc-blocks"
-version = "0.7.0"
+version = "0.7.1-dev"
 dependencies = [
  "hotg-rune-core",
  "hotg-rune-proc-block-macros",
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "hotg-rune-runtime"
-version = "0.7.0"
+version = "0.7.1-dev"
 dependencies = [
  "anyhow",
  "hotg-rune-core",
@@ -1223,7 +1223,7 @@ dependencies = [
 
 [[package]]
 name = "hotg-rune-syntax"
-version = "0.7.0"
+version = "0.7.1-dev"
 dependencies = [
  "codespan",
  "codespan-reporting",
@@ -1237,7 +1237,7 @@ dependencies = [
 
 [[package]]
 name = "hotg-rune-wasm3-runtime"
-version = "0.7.0"
+version = "0.7.1-dev"
 dependencies = [
  "anyhow",
  "hotg-rune-core",
@@ -1249,7 +1249,7 @@ dependencies = [
 
 [[package]]
 name = "hotg-rune-wasmer-runtime"
-version = "0.7.0"
+version = "0.7.1-dev"
 dependencies = [
  "anyhow",
  "hotg-rune-core",
@@ -1274,7 +1274,7 @@ dependencies = [
 
 [[package]]
 name = "hotg-runicos-base-runtime"
-version = "0.7.0"
+version = "0.7.1-dev"
 dependencies = [
  "anyhow",
  "hotg-rune-core",
@@ -1293,7 +1293,7 @@ dependencies = [
 
 [[package]]
 name = "hotg-runicos-base-wasm"
-version = "0.7.0"
+version = "0.7.1-dev"
 dependencies = [
  "dlmalloc",
  "hotg-rune-core",
@@ -1368,7 +1368,7 @@ dependencies = [
 
 [[package]]
 name = "image-normalization"
-version = "0.7.0"
+version = "0.7.1-dev"
 dependencies = [
  "hotg-rune-core",
  "hotg-rune-proc-blocks",
@@ -1484,7 +1484,7 @@ dependencies = [
 
 [[package]]
 name = "label"
-version = "0.7.0"
+version = "0.7.1-dev"
 dependencies = [
  "hotg-rune-core",
  "hotg-rune-proc-blocks",
@@ -1712,7 +1712,7 @@ dependencies = [
 
 [[package]]
 name = "modulo"
-version = "0.7.0"
+version = "0.7.1-dev"
 dependencies = [
  "hotg-rune-proc-blocks",
  "num-traits",
@@ -1726,7 +1726,7 @@ checksum = "0debeb9fcf88823ea64d64e4a815ab1643f33127d995978e099942ce38f25238"
 
 [[package]]
 name = "most_confident_indices"
-version = "0.7.0"
+version = "0.7.1-dev"
 dependencies = [
  "hotg-rune-core",
  "hotg-rune-proc-blocks",
@@ -1761,7 +1761,7 @@ dependencies = [
 
 [[package]]
 name = "noise-filtering"
-version = "0.7.0"
+version = "0.7.1-dev"
 dependencies = [
  "hotg-rune-core",
  "hotg-rune-proc-blocks",
@@ -1781,7 +1781,7 @@ dependencies = [
 
 [[package]]
 name = "normalize"
-version = "0.7.0"
+version = "0.7.1-dev"
 dependencies = [
  "hotg-rune-proc-blocks",
 ]
@@ -2455,7 +2455,7 @@ dependencies = [
 
 [[package]]
 name = "rune_py"
-version = "0.7.0"
+version = "0.7.1-dev"
 dependencies = [
  "fft",
  "hotg-rune-core",
@@ -3416,7 +3416,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "xtask"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "anyhow",
  "cargo_toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,4 @@ members = [
 exclude = ["bindings/web"]
 
 [patch.crates-io]
-serde_yaml = { git = "https://github.com/hotg-ai/serde-yaml", branch = "spans" }
-wasm3 = { git = "https://github.com/wasm3/wasm3-rs.git", rev = "51829c4985fbd7bcc1b52a289f4359617a258589" }
+#serde_yaml = { git = "https://github.com/hotg-ai/serde-yaml", branch = "spans" }

--- a/bindings/native/Cargo.toml
+++ b/bindings/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hotg-rune-native"
-version = "0.6.1-dev"
+version = "0.7.0"
 edition = "2018"
 publish = false
 authors = ["The Rune Developers <developers@hotg.ai>"]
@@ -16,11 +16,11 @@ anyhow = "1.0"
 build-info = "0.0.24"
 log = "0.4.14"
 paste = "1.0"
-hotg-rune-core = { path = "../../crates/rune-core", version = "^0.6.1-dev"}
-hotg-rune-runtime = { path = "../../crates/runtime", version = "^0.6.1-dev"}
-hotg-rune-wasmer-runtime = { path = "../../crates/wasmer-runtime", version = "^0.6.1-dev", optional = true }
-hotg-rune-wasm3-runtime = { path = "../../crates/wasm3-runtime", version = "^0.6.1-dev", optional = true }
-hotg-runicos-base-runtime = { path = "../../images/runicos-base/runtime", version = "^0.6.1-dev", default-features = false }
+hotg-rune-core = { path = "../../crates/rune-core", version = "^0.7.0"}
+hotg-rune-runtime = { path = "../../crates/runtime", version = "^0.7.0"}
+hotg-rune-wasmer-runtime = { path = "../../crates/wasmer-runtime", version = "^0.7.0", optional = true }
+hotg-rune-wasm3-runtime = { path = "../../crates/wasm3-runtime", version = "^0.7.0", optional = true }
+hotg-runicos-base-runtime = { path = "../../images/runicos-base/runtime", version = "^0.7.0", default-features = false }
 safer-ffi = { version = "0.0.6", features = ["proc_macros"] }
 
 [build-dependencies]

--- a/bindings/native/Cargo.toml
+++ b/bindings/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hotg-rune-native"
-version = "0.7.0"
+version = "0.7.1-dev"
 edition = "2018"
 publish = false
 authors = ["The Rune Developers <developers@hotg.ai>"]
@@ -16,11 +16,11 @@ anyhow = "1.0"
 build-info = "0.0.24"
 log = "0.4.14"
 paste = "1.0"
-hotg-rune-core = { path = "../../crates/rune-core", version = "^0.7.0"}
-hotg-rune-runtime = { path = "../../crates/runtime", version = "^0.7.0"}
-hotg-rune-wasmer-runtime = { path = "../../crates/wasmer-runtime", version = "^0.7.0", optional = true }
-hotg-rune-wasm3-runtime = { path = "../../crates/wasm3-runtime", version = "^0.7.0", optional = true }
-hotg-runicos-base-runtime = { path = "../../images/runicos-base/runtime", version = "^0.7.0", default-features = false }
+hotg-rune-core = { path = "../../crates/rune-core", version = "^0.7.1-dev"}
+hotg-rune-runtime = { path = "../../crates/runtime", version = "^0.7.1-dev"}
+hotg-rune-wasmer-runtime = { path = "../../crates/wasmer-runtime", version = "^0.7.1-dev", optional = true }
+hotg-rune-wasm3-runtime = { path = "../../crates/wasm3-runtime", version = "^0.7.1-dev", optional = true }
+hotg-runicos-base-runtime = { path = "../../images/runicos-base/runtime", version = "^0.7.1-dev", default-features = false }
 safer-ffi = { version = "0.0.6", features = ["proc_macros"] }
 
 [build-dependencies]

--- a/bindings/native/Cargo.toml
+++ b/bindings/native/Cargo.toml
@@ -12,10 +12,10 @@ license = "MIT OR Apache 2.0"
 crate-type = ["staticlib", "cdylib"]
 
 [dependencies]
-anyhow = "1.0.41"
-build-info = "0.0.23"
+anyhow = "1.0"
+build-info = "0.0.24"
 log = "0.4.14"
-paste = "1.0.5"
+paste = "1.0"
 hotg-rune-core = { path = "../../crates/rune-core", version = "^0.6.1-dev"}
 hotg-rune-runtime = { path = "../../crates/runtime", version = "^0.6.1-dev"}
 hotg-rune-wasmer-runtime = { path = "../../crates/wasmer-runtime", version = "^0.6.1-dev", optional = true }
@@ -24,7 +24,7 @@ hotg-runicos-base-runtime = { path = "../../images/runicos-base/runtime", versio
 safer-ffi = { version = "0.0.6", features = ["proc_macros"] }
 
 [build-dependencies]
-build-info-build = "0.0.23"
+build-info-build = "0.0.24"
 
 [features]
 c-headers = ["safer-ffi/headers"]

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rune_py"
-version = "0.6.1-dev"
+version = "0.7.0"
 authors = ["The Rune Developers <developers@hotg.ai>"]
 edition = "2018"
 publish = false
@@ -13,12 +13,12 @@ doctest = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-fft = { path = "../../proc-blocks/fft", version = "^0.6.1-dev"}
-hotg-rune-core = { path = "../../crates/rune-core", version = "^0.6.1-dev"}
-hotg-rune-proc-blocks = { path = "../../proc-blocks/proc-blocks", version = "^0.6.1-dev"}
-image-normalization = { path = "../../proc-blocks/image-normalization", version = "^0.6.1-dev"}
-noise-filtering = { path = "../../proc-blocks/noise-filtering", version = "^0.6.1-dev"}
-normalize = { path = "../../proc-blocks/normalize", version = "^0.6.1-dev"}
+fft = { path = "../../proc-blocks/fft", version = "^0.7.0"}
+hotg-rune-core = { path = "../../crates/rune-core", version = "^0.7.0"}
+hotg-rune-proc-blocks = { path = "../../proc-blocks/proc-blocks", version = "^0.7.0"}
+image-normalization = { path = "../../proc-blocks/image-normalization", version = "^0.7.0"}
+noise-filtering = { path = "../../proc-blocks/noise-filtering", version = "^0.7.0"}
+normalize = { path = "../../proc-blocks/normalize", version = "^0.7.0"}
 numpy = "0.14"
 paste = "1.0"
 pyo3 = { version = "0.14", features = ["extension-module", "abi3", "abi3-py36", "multiple-pymethods"] }

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rune_py"
-version = "0.7.0"
+version = "0.7.1-dev"
 authors = ["The Rune Developers <developers@hotg.ai>"]
 edition = "2018"
 publish = false
@@ -13,12 +13,12 @@ doctest = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-fft = { path = "../../proc-blocks/fft", version = "^0.7.0"}
-hotg-rune-core = { path = "../../crates/rune-core", version = "^0.7.0"}
-hotg-rune-proc-blocks = { path = "../../proc-blocks/proc-blocks", version = "^0.7.0"}
-image-normalization = { path = "../../proc-blocks/image-normalization", version = "^0.7.0"}
-noise-filtering = { path = "../../proc-blocks/noise-filtering", version = "^0.7.0"}
-normalize = { path = "../../proc-blocks/normalize", version = "^0.7.0"}
+fft = { path = "../../proc-blocks/fft", version = "^0.7.1-dev"}
+hotg-rune-core = { path = "../../crates/rune-core", version = "^0.7.1-dev"}
+hotg-rune-proc-blocks = { path = "../../proc-blocks/proc-blocks", version = "^0.7.1-dev"}
+image-normalization = { path = "../../proc-blocks/image-normalization", version = "^0.7.1-dev"}
+noise-filtering = { path = "../../proc-blocks/noise-filtering", version = "^0.7.1-dev"}
+normalize = { path = "../../proc-blocks/normalize", version = "^0.7.1-dev"}
 numpy = "0.14"
 paste = "1.0"
 pyo3 = { version = "0.14", features = ["extension-module", "abi3", "abi3-py36", "multiple-pymethods"] }

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -14,14 +14,14 @@ doctest = false
 
 [dependencies]
 fft = { path = "../../proc-blocks/fft", version = "^0.6.1-dev"}
+hotg-rune-core = { path = "../../crates/rune-core", version = "^0.6.1-dev"}
+hotg-rune-proc-blocks = { path = "../../proc-blocks/proc-blocks", version = "^0.6.1-dev"}
 image-normalization = { path = "../../proc-blocks/image-normalization", version = "^0.6.1-dev"}
 noise-filtering = { path = "../../proc-blocks/noise-filtering", version = "^0.6.1-dev"}
 normalize = { path = "../../proc-blocks/normalize", version = "^0.6.1-dev"}
-numpy = "0.13.1"
-paste = "1.0.5"
-pyo3 = { version = "0.13.2", features = ["extension-module", "abi3", "abi3-py36"] }
-hotg-rune-proc-blocks = { path = "../../proc-blocks/proc-blocks", version = "^0.6.1-dev"}
-hotg-rune-core = { path = "../../crates/rune-core", version = "^0.6.1-dev"}
+numpy = "0.14"
+paste = "1.0"
+pyo3 = { version = "0.14", features = ["extension-module", "abi3", "abi3-py36"] }
 
 [[test]]
 name = "python-unittest"

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -21,7 +21,7 @@ noise-filtering = { path = "../../proc-blocks/noise-filtering", version = "^0.6.
 normalize = { path = "../../proc-blocks/normalize", version = "^0.6.1-dev"}
 numpy = "0.14"
 paste = "1.0"
-pyo3 = { version = "0.14", features = ["extension-module", "abi3", "abi3-py36"] }
+pyo3 = { version = "0.14", features = ["extension-module", "abi3", "abi3-py36", "multiple-pymethods"] }
 
 [[test]]
 name = "python-unittest"

--- a/crates/codegen/Cargo.toml
+++ b/crates/codegen/Cargo.toml
@@ -16,7 +16,7 @@ readme = "README.md"
 [dependencies]
 anyhow = "1.0.38"
 build-info = { version = "0.0.24", features = ["serde"] }
-cargo_toml = "0.9.2"
+cargo_toml = "0.10"
 heck = "0.3.2"
 log = "0.4.14"
 proc-macro2 = "1.0.27"

--- a/crates/codegen/Cargo.toml
+++ b/crates/codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hotg-rune-codegen"
-version = "0.7.0"
+version = "0.7.1-dev"
 authors = ["The Rune Developers <developers@hotg.ai>"]
 edition = "2018"
 description = "Code generation for compiling a Runefile to WebAssembly."
@@ -21,8 +21,8 @@ heck = "0.3.2"
 log = "0.4.14"
 proc-macro2 = "1.0.27"
 quote = "1.0"
-hotg-rune-core = { path = "../rune-core", version = "^0.7.0"}
-hotg-rune-syntax = { path = "../syntax", version = "^0.7.0"}
+hotg-rune-core = { path = "../rune-core", version = "^0.7.1-dev"}
+hotg-rune-syntax = { path = "../syntax", version = "^0.7.1-dev"}
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 toml = "0.5.8"

--- a/crates/codegen/Cargo.toml
+++ b/crates/codegen/Cargo.toml
@@ -15,8 +15,8 @@ readme = "README.md"
 
 [dependencies]
 anyhow = "1.0.38"
-build-info = { version = "0.0.23", features = ["serde"] }
-cargo_toml = "0.9.1"
+build-info = { version = "0.0.24", features = ["serde"] }
+cargo_toml = "0.9.2"
 heck = "0.3.2"
 log = "0.4.14"
 proc-macro2 = "1.0.27"

--- a/crates/codegen/Cargo.toml
+++ b/crates/codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hotg-rune-codegen"
-version = "0.6.1-dev"
+version = "0.7.0"
 authors = ["The Rune Developers <developers@hotg.ai>"]
 edition = "2018"
 description = "Code generation for compiling a Runefile to WebAssembly."
@@ -21,8 +21,8 @@ heck = "0.3.2"
 log = "0.4.14"
 proc-macro2 = "1.0.27"
 quote = "1.0"
-hotg-rune-core = { path = "../rune-core", version = "^0.6.1-dev"}
-hotg-rune-syntax = { path = "../syntax", version = "^0.6.1-dev"}
+hotg-rune-core = { path = "../rune-core", version = "^0.7.0"}
+hotg-rune-syntax = { path = "../syntax", version = "^0.7.0"}
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 toml = "0.5.8"

--- a/crates/codegen/src/manifest.rs
+++ b/crates/codegen/src/manifest.rs
@@ -29,7 +29,8 @@ pub(crate) fn generate(
         workspace: Some(Workspace {
             members: vec![String::from(".")],
             default_members: vec![String::from(".")],
-            ..Default::default()
+            exclude: Vec::new(),
+            metadata: None,
         }),
         ..empty_manifest()
     }

--- a/crates/rune-cli/Cargo.toml
+++ b/crates/rune-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hotg-rune-cli"
-version = "0.6.1-dev"
+version = "0.7.0"
 edition = "2018"
 authors = ["The Rune Developers <developers@hotg.ai>"]
 description = "A self-sufficient runtime for TinyML Containers."
@@ -18,14 +18,14 @@ chrono = { version = "0.4.19", features = ["std"] }
 codespan-reporting = "0.11.0"
 dirs = "3.0"
 env_logger = "0.9"
-hotg-rune-codegen = { path = "../codegen", version = "^0.6.1-dev"}
-hotg-rune-core = { path = "../rune-core", version = "^0.6.1-dev"}
-hotg-rune-runtime = { path = "../runtime", version = "^0.6.1-dev"}
-hotg-rune-syntax = { path = "../syntax", version = "^0.6.1-dev"}
-hotg-rune-wasm3-runtime = { path = "../wasm3-runtime", version = "^0.6.1-dev"}
-hotg-rune-wasmer-runtime = { path = "../wasmer-runtime", version = "^0.6.1-dev"}
+hotg-rune-codegen = { path = "../codegen", version = "^0.7.0"}
+hotg-rune-core = { path = "../rune-core", version = "^0.7.0"}
+hotg-rune-runtime = { path = "../runtime", version = "^0.7.0"}
+hotg-rune-syntax = { path = "../syntax", version = "^0.7.0"}
+hotg-rune-wasm3-runtime = { path = "../wasm3-runtime", version = "^0.7.0"}
+hotg-rune-wasmer-runtime = { path = "../wasmer-runtime", version = "^0.7.0"}
 hotg-runecoral = "0.1.1"
-hotg-runicos-base-runtime = { path = "../../images/runicos-base/runtime", version = "^0.6.1-dev", features = ["tflite", "wasm3-runtime"] }
+hotg-runicos-base-runtime = { path = "../../images/runicos-base/runtime", version = "^0.7.0", features = ["tflite", "wasm3-runtime"] }
 hound = "3.4.0"
 image = "0.23.14"
 indexmap = "1.6.2"

--- a/crates/rune-cli/Cargo.toml
+++ b/crates/rune-cli/Cargo.toml
@@ -12,46 +12,44 @@ keywords = ["rune", "tinyml", "container", "machine", "learning"]
 readme = "README.md"
 
 [dependencies]
-anyhow = "1.0.38"
-build-info = { version = "0.0.23", features = ["serde"] }
+anyhow = "1.0"
+build-info = { version = "0.0.24", features = ["serde"] }
 chrono = { version = "0.4.19", features = ["std"] }
-clap = "2.33.3"
 codespan-reporting = "0.11.0"
-dirs = "3.0.1"
-env_logger = "0.8.1"
+dirs = "3.0"
+env_logger = "0.9"
+hotg-rune-codegen = { path = "../codegen", version = "^0.6.1-dev"}
+hotg-rune-core = { path = "../rune-core", version = "^0.6.1-dev"}
+hotg-rune-runtime = { path = "../runtime", version = "^0.6.1-dev"}
+hotg-rune-syntax = { path = "../syntax", version = "^0.6.1-dev"}
+hotg-rune-wasm3-runtime = { path = "../wasm3-runtime", version = "^0.6.1-dev"}
+hotg-rune-wasmer-runtime = { path = "../wasmer-runtime", version = "^0.6.1-dev"}
+hotg-runecoral = "0.1.1"
+hotg-runicos-base-runtime = { path = "../../images/runicos-base/runtime", version = "^0.6.1-dev", features = ["tflite", "wasm3-runtime"] }
 hound = "3.4.0"
 image = "0.23.14"
 indexmap = "1.6.2"
-log = { version = "0.4.11" }
+log = "0.4.11"
 once_cell = "1.7.0"
-petgraph = "0.5.1"
 rand = "0.8.3"
-hotg-rune-codegen = { path = "../codegen", version = "^0.6.1-dev"}
-hotg-rune-runtime = { path = "../runtime", version = "^0.6.1-dev"}
-hotg-rune-syntax = { path = "../syntax", version = "^0.6.1-dev"}
-hotg-rune-wasmer-runtime = { path = "../wasmer-runtime", version = "^0.6.1-dev"}
-hotg-rune-wasm3-runtime = { path = "../wasm3-runtime", version = "^0.6.1-dev"}
-hotg-rune-core = { path = "../rune-core", version = "^0.6.1-dev"}
-hotg-runicos-base-runtime = { path = "../../images/runicos-base/runtime", version = "^0.6.1-dev", features = ["tflite", "wasm3-runtime"] }
+regex = "1.5.4"
 serde = { version = "1.0.125", features = ["derive"] }
 serde_json = "1.0.64"
 structopt = "0.3.21"
-strum = { version = "0.20.0", features = ["derive"] }
+strum = { version = "0.21.0", features = ["derive"] }
 tflite = "0.9.5"
-wasmparser = "0.78.2"
-hotg-runecoral = "0.1.1"
-regex = "1.5.4"
+wasmparser = "0.80"
 
 [dev-dependencies]
-assert_cmd = "1.0.3"
-predicates = "1.0.7"
-tempfile = "3.2.0"
-walkdir = "2.3.2"
+assert_cmd = "2"
+predicates = "2"
+tempfile = "3"
+walkdir = "2"
 criterion = "0.3"
 tempdir = "0.3"
 
 [build-dependencies]
-build-info-build = "0.0.23"
+build-info-build = "0.0.24"
 
 [[bench]]
 name = "rune_benchmark"

--- a/crates/rune-cli/Cargo.toml
+++ b/crates/rune-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hotg-rune-cli"
-version = "0.7.0"
+version = "0.7.1-dev"
 edition = "2018"
 authors = ["The Rune Developers <developers@hotg.ai>"]
 description = "A self-sufficient runtime for TinyML Containers."
@@ -18,14 +18,14 @@ chrono = { version = "0.4.19", features = ["std"] }
 codespan-reporting = "0.11.0"
 dirs = "3.0"
 env_logger = "0.9"
-hotg-rune-codegen = { path = "../codegen", version = "^0.7.0"}
-hotg-rune-core = { path = "../rune-core", version = "^0.7.0"}
-hotg-rune-runtime = { path = "../runtime", version = "^0.7.0"}
-hotg-rune-syntax = { path = "../syntax", version = "^0.7.0"}
-hotg-rune-wasm3-runtime = { path = "../wasm3-runtime", version = "^0.7.0"}
-hotg-rune-wasmer-runtime = { path = "../wasmer-runtime", version = "^0.7.0"}
+hotg-rune-codegen = { path = "../codegen", version = "^0.7.1-dev"}
+hotg-rune-core = { path = "../rune-core", version = "^0.7.1-dev"}
+hotg-rune-runtime = { path = "../runtime", version = "^0.7.1-dev"}
+hotg-rune-syntax = { path = "../syntax", version = "^0.7.1-dev"}
+hotg-rune-wasm3-runtime = { path = "../wasm3-runtime", version = "^0.7.1-dev"}
+hotg-rune-wasmer-runtime = { path = "../wasmer-runtime", version = "^0.7.1-dev"}
 hotg-runecoral = "0.1.1"
-hotg-runicos-base-runtime = { path = "../../images/runicos-base/runtime", version = "^0.7.0", features = ["tflite", "wasm3-runtime"] }
+hotg-runicos-base-runtime = { path = "../../images/runicos-base/runtime", version = "^0.7.1-dev", features = ["tflite", "wasm3-runtime"] }
 hound = "3.4.0"
 image = "0.23.14"
 indexmap = "1.6.2"

--- a/crates/rune-core/Cargo.toml
+++ b/crates/rune-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hotg-rune-core"
-version = "0.6.1-dev"
+version = "0.7.0"
 description = "Core abstractions and types used across the Rune platform."
 edition = "2018"
 authors = ["The Rune Developers <developers@hotg.ai>"]

--- a/crates/rune-core/Cargo.toml
+++ b/crates/rune-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hotg-rune-core"
-version = "0.7.0"
+version = "0.7.1-dev"
 description = "Core abstractions and types used across the Rune platform."
 edition = "2018"
 authors = ["The Rune Developers <developers@hotg.ai>"]

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hotg-rune-runtime"
-version = "0.7.0"
+version = "0.7.1-dev"
 edition = "2018"
 authors = ["The Rune Developers <developers@hotg.ai>"]
 license = "MIT OR Apache-2.0"
@@ -19,7 +19,7 @@ hound = { version = "3.4.0", optional = true }
 image = { version = "0.23.14", optional = true }
 log = "0.4.14"
 rand = { version = "0.8.3", optional = true }
-hotg-rune-core = { path = "../rune-core", version = "^0.7.0", features = ["std"] }
+hotg-rune-core = { path = "../rune-core", version = "^0.7.1-dev", features = ["std"] }
 thiserror = "1.0.24"
 
 [features]

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hotg-rune-runtime"
-version = "0.6.1-dev"
+version = "0.7.0"
 edition = "2018"
 authors = ["The Rune Developers <developers@hotg.ai>"]
 license = "MIT OR Apache-2.0"
@@ -19,7 +19,7 @@ hound = { version = "3.4.0", optional = true }
 image = { version = "0.23.14", optional = true }
 log = "0.4.14"
 rand = { version = "0.8.3", optional = true }
-hotg-rune-core = { path = "../rune-core", version = "^0.6.1-dev", features = ["std"] }
+hotg-rune-core = { path = "../rune-core", version = "^0.7.0", features = ["std"] }
 thiserror = "1.0.24"
 
 [features]

--- a/crates/syntax/Cargo.toml
+++ b/crates/syntax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hotg-rune-syntax"
-version = "0.6.1-dev"
+version = "0.7.0"
 authors = ["The Rune Developers <developers@hotg.ai>"]
 edition = "2018"
 description = "Runefile parsing and analysis."

--- a/crates/syntax/Cargo.toml
+++ b/crates/syntax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hotg-rune-syntax"
-version = "0.7.0"
+version = "0.7.1-dev"
 authors = ["The Rune Developers <developers@hotg.ai>"]
 edition = "2018"
 description = "Runefile parsing and analysis."

--- a/crates/wasm3-runtime/Cargo.toml
+++ b/crates/wasm3-runtime/Cargo.toml
@@ -14,11 +14,11 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.40"
+anyhow = "1.0"
 log = "0.4.14"
 hotg-rune-runtime = { path = "../runtime", version = "^0.6.1-dev"}
 hotg-rune-core = { path = "../rune-core", version = "^0.6.1-dev"}
-wasm3 = "0.2.0"
+wasm3 = "0.3.0"
 
 [dev-dependencies]
 tempfile = "3.2.0"

--- a/crates/wasm3-runtime/Cargo.toml
+++ b/crates/wasm3-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hotg-rune-wasm3-runtime"
-version = "0.7.0"
+version = "0.7.1-dev"
 authors = ["The Rune Developers <developers@hotg.ai>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -16,8 +16,8 @@ readme = "README.md"
 [dependencies]
 anyhow = "1.0"
 log = "0.4.14"
-hotg-rune-runtime = { path = "../runtime", version = "^0.7.0"}
-hotg-rune-core = { path = "../rune-core", version = "^0.7.0"}
+hotg-rune-runtime = { path = "../runtime", version = "^0.7.1-dev"}
+hotg-rune-core = { path = "../rune-core", version = "^0.7.1-dev"}
 wasm3 = "0.3.0"
 
 [dev-dependencies]

--- a/crates/wasm3-runtime/Cargo.toml
+++ b/crates/wasm3-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hotg-rune-wasm3-runtime"
-version = "0.6.1-dev"
+version = "0.7.0"
 authors = ["The Rune Developers <developers@hotg.ai>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -16,8 +16,8 @@ readme = "README.md"
 [dependencies]
 anyhow = "1.0"
 log = "0.4.14"
-hotg-rune-runtime = { path = "../runtime", version = "^0.6.1-dev"}
-hotg-rune-core = { path = "../rune-core", version = "^0.6.1-dev"}
+hotg-rune-runtime = { path = "../runtime", version = "^0.7.0"}
+hotg-rune-core = { path = "../rune-core", version = "^0.7.0"}
 wasm3 = "0.3.0"
 
 [dev-dependencies]

--- a/crates/wasmer-runtime/Cargo.toml
+++ b/crates/wasmer-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hotg-rune-wasmer-runtime"
-version = "0.6.1-dev"
+version = "0.7.0"
 authors = ["The Rune Developers <developers@hotg.ai>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -16,8 +16,8 @@ readme = "README.md"
 [dependencies]
 anyhow = "1.0.40"
 log = "0.4.14"
-hotg-rune-runtime = { path = "../runtime", version = "^0.6.1-dev"}
-hotg-rune-core = { path = "../rune-core", version = "^0.6.1-dev"}
+hotg-rune-runtime = { path = "../runtime", version = "^0.7.0"}
+hotg-rune-core = { path = "../rune-core", version = "^0.7.0"}
 wasmer = "2.0"
 wasmer-types = "2.0"
 wasmer-vm = "2.0"

--- a/crates/wasmer-runtime/Cargo.toml
+++ b/crates/wasmer-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hotg-rune-wasmer-runtime"
-version = "0.7.0"
+version = "0.7.1-dev"
 authors = ["The Rune Developers <developers@hotg.ai>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -16,8 +16,8 @@ readme = "README.md"
 [dependencies]
 anyhow = "1.0.40"
 log = "0.4.14"
-hotg-rune-runtime = { path = "../runtime", version = "^0.7.0"}
-hotg-rune-core = { path = "../rune-core", version = "^0.7.0"}
+hotg-rune-runtime = { path = "../runtime", version = "^0.7.1-dev"}
+hotg-rune-core = { path = "../rune-core", version = "^0.7.1-dev"}
 wasmer = "2.0"
 wasmer-types = "2.0"
 wasmer-vm = "2.0"

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtask"
-version = "0.1.1-dev"
+version = "0.2.0"
 authors = ["The Rune Developers <developers@hotg.ai>"]
 edition = "2018"
 publish = false
@@ -15,7 +15,7 @@ codespan-reporting = "0.11.1"
 env_logger = "0.9"
 globset = "0.4.6"
 log = "0.4.14"
-hotg-rune-syntax = { path = "../syntax", version = "^0.6.1-dev"}
+hotg-rune-syntax = { path = "../syntax", version = "^0.7.0"}
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 structopt = "0.3.21"

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -10,9 +10,8 @@ description = "Utilities used during development."
 
 [dependencies]
 anyhow = "1.0"
-cargo_toml = "0.9.2"
+cargo_toml = "0.10"
 codespan-reporting = "0.11.1"
-devx-pre-commit = "0.3.1"
 env_logger = "0.9"
 globset = "0.4.6"
 log = "0.4.14"

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -9,16 +9,16 @@ description = "Utilities used during development."
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.38"
+anyhow = "1.0"
 cargo_toml = "0.9.2"
 codespan-reporting = "0.11.1"
 devx-pre-commit = "0.3.1"
-env_logger = "0.8.3"
+env_logger = "0.9"
 globset = "0.4.6"
 log = "0.4.14"
 hotg-rune-syntax = { path = "../syntax", version = "^0.6.1-dev"}
-serde = { version = "1.0.124", features = ["derive"] }
-serde_json = "1.0.64"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 structopt = "0.3.21"
 walkdir = "2.3.1"
 zip = "0.5.11"

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtask"
-version = "0.2.0"
+version = "0.2.1-dev"
 authors = ["The Rune Developers <developers@hotg.ai>"]
 edition = "2018"
 publish = false
@@ -15,7 +15,7 @@ codespan-reporting = "0.11.1"
 env_logger = "0.9"
 globset = "0.4.6"
 log = "0.4.14"
-hotg-rune-syntax = { path = "../syntax", version = "^0.7.0"}
+hotg-rune-syntax = { path = "../syntax", version = "^0.7.1-dev"}
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 structopt = "0.3.21"

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -3,33 +3,21 @@ mod check_manifests;
 mod dist;
 
 use crate::{bulk_copy::BulkCopy, check_manifests::CheckManifests, dist::Dist};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use anyhow::{Context, Error};
-use devx_pre_commit::PreCommitContext;
 use env_logger::Env;
 use structopt::StructOpt;
 
 fn main() -> Result<(), Error> {
-    let project_root = devx_pre_commit::locate_project_root()
-        .context("Unable to find the project root")?;
-
-    if is_pre_commit() {
-        return run_pre_commit_hook(&project_root);
-    }
-
     let env = Env::new().default_filter_or("info,cbindgen=warn,globset=info");
     env_logger::builder().parse_env(env).init();
 
     let cmd = Command::from_args();
 
     log::debug!("Running {:?}", cmd);
+    let project_root = project_root()?;
 
     match cmd {
-        Command::InstallPreCommit => {
-            log::info!("Installing this binary as the pre-commit hook");
-            devx_pre_commit::install_self_as_hook(&project_root)
-                .context("Unable to install the pre-commit hook")?;
-        },
         Command::Dist(dist) => dist.run()?,
         Command::CheckManifests(c) => c.run(&project_root)?,
     }
@@ -37,29 +25,8 @@ fn main() -> Result<(), Error> {
     Ok(())
 }
 
-fn is_pre_commit() -> bool {
-    match std::env::args().next() {
-        Some(binary_name) => binary_name.contains("pre-commit"),
-        None => false,
-    }
-}
-
-fn run_pre_commit_hook(project_root: &Path) -> Result<(), Error> {
-    let ctx = PreCommitContext::from_git_diff(project_root)
-        .context("Unable to load the pre-commit context")?;
-    ctx.rustfmt().context("rustfmt failed")?;
-    ctx.stage_new_changes().context("Unable to stage changes")?;
-
-    Ok(())
-}
-
 #[derive(Debug, StructOpt)]
 enum Command {
-    #[structopt(
-        name = "install-pre-commit-hook",
-        about = "Install the common pre-commit hook"
-    )]
-    InstallPreCommit,
     #[structopt(name = "dist", about = "Generate a release bundle")]
     Dist(Dist),
     #[structopt(

--- a/images/runicos-base/runtime/Cargo.toml
+++ b/images/runicos-base/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hotg-runicos-base-runtime"
-version = "0.7.0"
+version = "0.7.1-dev"
 edition = "2018"
 authors = ["The Rune Developers <developers@hotg.ai>"]
 license = "MIT OR Apache-2.0"
@@ -15,10 +15,10 @@ readme = "README.md"
 
 [dependencies]
 anyhow = "1.0.40"
-hotg-rune-core = { path = "../../../crates/rune-core", version = "^0.7.0", features = ["std"] }
-hotg-rune-runtime = { path = "../../../crates/runtime", version = "^0.7.0", features = ["builtins"] }
-hotg-rune-wasmer-runtime = { path = "../../../crates/wasmer-runtime", version = "^0.7.0", optional = true }
-hotg-rune-wasm3-runtime = { path = "../../../crates/wasm3-runtime", version = "^0.7.0", optional = true }
+hotg-rune-core = { path = "../../../crates/rune-core", version = "^0.7.1-dev", features = ["std"] }
+hotg-rune-runtime = { path = "../../../crates/runtime", version = "^0.7.1-dev", features = ["builtins"] }
+hotg-rune-wasmer-runtime = { path = "../../../crates/wasmer-runtime", version = "^0.7.1-dev", optional = true }
+hotg-rune-wasm3-runtime = { path = "../../../crates/wasm3-runtime", version = "^0.7.1-dev", optional = true }
 log = "0.4.14"
 rand = "0.8.4"
 serde_json = { version = "1" }

--- a/images/runicos-base/runtime/Cargo.toml
+++ b/images/runicos-base/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hotg-runicos-base-runtime"
-version = "0.6.1-dev"
+version = "0.7.0"
 edition = "2018"
 authors = ["The Rune Developers <developers@hotg.ai>"]
 license = "MIT OR Apache-2.0"
@@ -15,10 +15,10 @@ readme = "README.md"
 
 [dependencies]
 anyhow = "1.0.40"
-hotg-rune-core = { path = "../../../crates/rune-core", version = "^0.6.1-dev", features = ["std"] }
-hotg-rune-runtime = { path = "../../../crates/runtime", version = "^0.6.1-dev", features = ["builtins"] }
-hotg-rune-wasmer-runtime = { path = "../../../crates/wasmer-runtime", version = "^0.6.1-dev", optional = true }
-hotg-rune-wasm3-runtime = { path = "../../../crates/wasm3-runtime", version = "^0.6.1-dev", optional = true }
+hotg-rune-core = { path = "../../../crates/rune-core", version = "^0.7.0", features = ["std"] }
+hotg-rune-runtime = { path = "../../../crates/runtime", version = "^0.7.0", features = ["builtins"] }
+hotg-rune-wasmer-runtime = { path = "../../../crates/wasmer-runtime", version = "^0.7.0", optional = true }
+hotg-rune-wasm3-runtime = { path = "../../../crates/wasm3-runtime", version = "^0.7.0", optional = true }
 log = "0.4.14"
 rand = "0.8.4"
 serde_json = { version = "1" }

--- a/images/runicos-base/runtime/Cargo.toml
+++ b/images/runicos-base/runtime/Cargo.toml
@@ -26,7 +26,7 @@ serde_json = { version = "1" }
 tflite = { version = "0.9.5", optional = true }
 wasmer = { version = "2.0.0", optional = true }
 wasmer-vm = { version = "2.0.0", optional = true }
-wasm3 = { version = "0.2.0", optional = true }
+wasm3 = { version = "0.3.0", optional = true }
 
 [features]
 default = ["tflite", "wasmer-runtime"]

--- a/images/runicos-base/wasm/Cargo.toml
+++ b/images/runicos-base/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hotg-runicos-base-wasm"
-version = "0.7.0"
+version = "0.7.1-dev"
 edition = "2018"
 authors = ["The Rune Developers <developers@hotg.ai>"]
 license = "MIT OR Apache-2.0"
@@ -16,7 +16,7 @@ readme = "README.md"
 [target.wasm32-unknown-unknown.dependencies]
 dlmalloc = { version = "0.2.1", features = ["global"] }
 log = "0.4.14"
-hotg-rune-core = { path = "../../../crates/rune-core", version = "^0.7.0"}
+hotg-rune-core = { path = "../../../crates/rune-core", version = "^0.7.1-dev"}
 serde = { version = "1.0.126", default-features = false }
 serde-json-core = { version = "0.4.0", default-features = false }
 serde_json = { version = "1.0.64", features = ["alloc"], default-features = false }

--- a/images/runicos-base/wasm/Cargo.toml
+++ b/images/runicos-base/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hotg-runicos-base-wasm"
-version = "0.6.1-dev"
+version = "0.7.0"
 edition = "2018"
 authors = ["The Rune Developers <developers@hotg.ai>"]
 license = "MIT OR Apache-2.0"
@@ -16,7 +16,7 @@ readme = "README.md"
 [target.wasm32-unknown-unknown.dependencies]
 dlmalloc = { version = "0.2.1", features = ["global"] }
 log = "0.4.14"
-hotg-rune-core = { path = "../../../crates/rune-core", version = "^0.6.1-dev"}
+hotg-rune-core = { path = "../../../crates/rune-core", version = "^0.7.0"}
 serde = { version = "1.0.126", default-features = false }
 serde-json-core = { version = "0.4.0", default-features = false }
 serde_json = { version = "1.0.64", features = ["alloc"], default-features = false }

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hotg-rune-integration-tests"
-version = "0.7.0"
+version = "0.7.1-dev"
 edition = "2018"
 publish = false
 

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hotg-rune-integration-tests"
-version = "0.6.1-dev"
+version = "0.7.0"
 edition = "2018"
 publish = false
 

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/bin/main.rs"
 
 [dependencies]
 anyhow = "1.0"
-env_logger = "0.8.3"
+env_logger = "0.9"
 log = "0.4.14"
 once_cell = "1.7.2"
 regex = "1.5.4"

--- a/proc-blocks/audio_float_conversion/Cargo.toml
+++ b/proc-blocks/audio_float_conversion/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "audio_float_conversion"
-version = "0.6.1-dev"
+version = "0.7.0"
 edition = "2018"
 publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-hotg-rune-core = { path = "../../crates/rune-core", version = "^0.6.1-dev"}
-hotg-rune-proc-blocks = { path = "../proc-blocks", version = "^0.6.1-dev"}
+hotg-rune-core = { path = "../../crates/rune-core", version = "^0.7.0"}
+hotg-rune-proc-blocks = { path = "../proc-blocks", version = "^0.7.0"}
 
 [dev-dependencies]
 pretty_assertions = "0.7.2"

--- a/proc-blocks/audio_float_conversion/Cargo.toml
+++ b/proc-blocks/audio_float_conversion/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "audio_float_conversion"
-version = "0.7.0"
+version = "0.7.1-dev"
 edition = "2018"
 publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-hotg-rune-core = { path = "../../crates/rune-core", version = "^0.7.0"}
-hotg-rune-proc-blocks = { path = "../proc-blocks", version = "^0.7.0"}
+hotg-rune-core = { path = "../../crates/rune-core", version = "^0.7.1-dev"}
+hotg-rune-proc-blocks = { path = "../proc-blocks", version = "^0.7.1-dev"}
 
 [dev-dependencies]
 pretty_assertions = "0.7.2"

--- a/proc-blocks/fft/Cargo.toml
+++ b/proc-blocks/fft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fft"
-version = "0.7.0"
+version = "0.7.1-dev"
 authors = ["The Rune Developers <developers@hotg.ai>"]
 edition = "2018"
 publish = false
@@ -8,14 +8,14 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-hotg-rune-core = { path = "../../crates/rune-core", version = "^0.7.0"}
-hotg-rune-proc-blocks = { path = "../proc-blocks", version = "^0.7.0"}
+hotg-rune-core = { path = "../../crates/rune-core", version = "^0.7.1-dev"}
+hotg-rune-proc-blocks = { path = "../proc-blocks", version = "^0.7.1-dev"}
 hound = "3.4"
 libm = "0.2.1"
 # See https://github.com/hotg-ai/rune/pull/107#issuecomment-825806000
 mel = { git = "https://github.com/hotg-ai/mel", rev = "017694ee3143c11ea9b75ba6cd27fe7c8a69a867", default-features = false }
 nalgebra = { version = "0.29", default-features = false, features = ["alloc"] }
-normalize = { path = "../normalize", version = "^0.7.0"}
+normalize = { path = "../normalize", version = "^0.7.1-dev"}
 sonogram = {git = "https://github.com/hotg-ai/sonogram", rev = "009bc0cba44267d8a0807e43c9bb0712f0f334ea" }
 
 [dev-dependencies]

--- a/proc-blocks/fft/Cargo.toml
+++ b/proc-blocks/fft/Cargo.toml
@@ -14,7 +14,7 @@ hound = "3.4"
 libm = "0.2.1"
 # See https://github.com/hotg-ai/rune/pull/107#issuecomment-825806000
 mel = { git = "https://github.com/hotg-ai/mel", rev = "017694ee3143c11ea9b75ba6cd27fe7c8a69a867", default-features = false }
-nalgebra = { version = "0.26.1", default-features = false, features = ["alloc"] }
+nalgebra = { version = "0.29", default-features = false, features = ["alloc"] }
 normalize = { path = "../normalize", version = "^0.6.1-dev"}
 sonogram = {git = "https://github.com/hotg-ai/sonogram", rev = "009bc0cba44267d8a0807e43c9bb0712f0f334ea" }
 

--- a/proc-blocks/fft/Cargo.toml
+++ b/proc-blocks/fft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fft"
-version = "0.6.1-dev"
+version = "0.7.0"
 authors = ["The Rune Developers <developers@hotg.ai>"]
 edition = "2018"
 publish = false
@@ -8,14 +8,14 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-hotg-rune-core = { path = "../../crates/rune-core", version = "^0.6.1-dev"}
-hotg-rune-proc-blocks = { path = "../proc-blocks", version = "^0.6.1-dev"}
+hotg-rune-core = { path = "../../crates/rune-core", version = "^0.7.0"}
+hotg-rune-proc-blocks = { path = "../proc-blocks", version = "^0.7.0"}
 hound = "3.4"
 libm = "0.2.1"
 # See https://github.com/hotg-ai/rune/pull/107#issuecomment-825806000
 mel = { git = "https://github.com/hotg-ai/mel", rev = "017694ee3143c11ea9b75ba6cd27fe7c8a69a867", default-features = false }
 nalgebra = { version = "0.29", default-features = false, features = ["alloc"] }
-normalize = { path = "../normalize", version = "^0.6.1-dev"}
+normalize = { path = "../normalize", version = "^0.7.0"}
 sonogram = {git = "https://github.com/hotg-ai/sonogram", rev = "009bc0cba44267d8a0807e43c9bb0712f0f334ea" }
 
 [dev-dependencies]

--- a/proc-blocks/image-normalization/Cargo.toml
+++ b/proc-blocks/image-normalization/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "image-normalization"
-version = "0.7.0"
+version = "0.7.1-dev"
 edition = "2018"
 publish = false
 
@@ -8,5 +8,5 @@ publish = false
 
 [dependencies]
 num-traits = { version = "0.2.14", default-features = false }
-hotg-rune-core = { path = "../../crates/rune-core", version = "^0.7.0"}
-hotg-rune-proc-blocks = { path = "../proc-blocks", version = "^0.7.0"}
+hotg-rune-core = { path = "../../crates/rune-core", version = "^0.7.1-dev"}
+hotg-rune-proc-blocks = { path = "../proc-blocks", version = "^0.7.1-dev"}

--- a/proc-blocks/image-normalization/Cargo.toml
+++ b/proc-blocks/image-normalization/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "image-normalization"
-version = "0.6.1-dev"
+version = "0.7.0"
 edition = "2018"
 publish = false
 
@@ -8,5 +8,5 @@ publish = false
 
 [dependencies]
 num-traits = { version = "0.2.14", default-features = false }
-hotg-rune-core = { path = "../../crates/rune-core", version = "^0.6.1-dev"}
-hotg-rune-proc-blocks = { path = "../proc-blocks", version = "^0.6.1-dev"}
+hotg-rune-core = { path = "../../crates/rune-core", version = "^0.7.0"}
+hotg-rune-proc-blocks = { path = "../proc-blocks", version = "^0.7.0"}

--- a/proc-blocks/label/Cargo.toml
+++ b/proc-blocks/label/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "label"
-version = "0.7.0"
+version = "0.7.1-dev"
 edition = "2018"
 publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-hotg-rune-proc-blocks = { path = "../proc-blocks", version = "^0.7.0"}
+hotg-rune-proc-blocks = { path = "../proc-blocks", version = "^0.7.1-dev"}
 
 [dev-dependencies]
-hotg-rune-core = { path = "../../crates/rune-core", version = "^0.7.0"}
+hotg-rune-core = { path = "../../crates/rune-core", version = "^0.7.1-dev"}

--- a/proc-blocks/label/Cargo.toml
+++ b/proc-blocks/label/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "label"
-version = "0.6.1-dev"
+version = "0.7.0"
 edition = "2018"
 publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-hotg-rune-proc-blocks = { path = "../proc-blocks", version = "^0.6.1-dev"}
+hotg-rune-proc-blocks = { path = "../proc-blocks", version = "^0.7.0"}
 
 [dev-dependencies]
-hotg-rune-core = { path = "../../crates/rune-core", version = "^0.6.1-dev"}
+hotg-rune-core = { path = "../../crates/rune-core", version = "^0.7.0"}

--- a/proc-blocks/macros/Cargo.toml
+++ b/proc-blocks/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hotg-rune-proc-block-macros"
-version = "0.7.0"
+version = "0.7.1-dev"
 edition = "2018"
 authors = ["The Rune Developers <developers@hotg.ai>"]
 license = "MIT OR Apache-2.0"
@@ -19,7 +19,7 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0.27"
 quote = "1.0.9"
-hotg-rune-core = { path = "../../crates/rune-core", version = "^0.7.0", default-features = false }
+hotg-rune-core = { path = "../../crates/rune-core", version = "^0.7.1-dev", default-features = false }
 serde = { version = "1.0.126", features = ["derive"] }
 serde_json = "1.0.64"
 syn = { version = "1.0.72", features = ["extra-traits", "full"] }

--- a/proc-blocks/macros/Cargo.toml
+++ b/proc-blocks/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hotg-rune-proc-block-macros"
-version = "0.6.1-dev"
+version = "0.7.0"
 edition = "2018"
 authors = ["The Rune Developers <developers@hotg.ai>"]
 license = "MIT OR Apache-2.0"
@@ -19,7 +19,7 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0.27"
 quote = "1.0.9"
-hotg-rune-core = { path = "../../crates/rune-core", version = "^0.6.1-dev", default-features = false }
+hotg-rune-core = { path = "../../crates/rune-core", version = "^0.7.0", default-features = false }
 serde = { version = "1.0.126", features = ["derive"] }
 serde_json = "1.0.64"
 syn = { version = "1.0.72", features = ["extra-traits", "full"] }

--- a/proc-blocks/modulo/Cargo.toml
+++ b/proc-blocks/modulo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "modulo"
-version = "0.6.1-dev"
+version = "0.7.0"
 authors = ["The Rune Developers <developers@hotg.ai>"]
 edition = "2018"
 publish = false
@@ -9,4 +9,4 @@ publish = false
 
 [dependencies]
 num-traits = { version = "0.2.14", default-features = false }
-hotg-rune-proc-blocks = { path = "../proc-blocks", version = "^0.6.1-dev"}
+hotg-rune-proc-blocks = { path = "../proc-blocks", version = "^0.7.0"}

--- a/proc-blocks/modulo/Cargo.toml
+++ b/proc-blocks/modulo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "modulo"
-version = "0.7.0"
+version = "0.7.1-dev"
 authors = ["The Rune Developers <developers@hotg.ai>"]
 edition = "2018"
 publish = false
@@ -9,4 +9,4 @@ publish = false
 
 [dependencies]
 num-traits = { version = "0.2.14", default-features = false }
-hotg-rune-proc-blocks = { path = "../proc-blocks", version = "^0.7.0"}
+hotg-rune-proc-blocks = { path = "../proc-blocks", version = "^0.7.1-dev"}

--- a/proc-blocks/most_confident_indices/Cargo.toml
+++ b/proc-blocks/most_confident_indices/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "most_confident_indices"
-version = "0.7.0"
+version = "0.7.1-dev"
 edition = "2018"
 publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-hotg-rune-proc-blocks = { path = "../proc-blocks", version = "^0.7.0"}
-hotg-rune-core = { path = "../../crates/rune-core", version = "^0.7.0"}
+hotg-rune-proc-blocks = { path = "../proc-blocks", version = "^0.7.1-dev"}
+hotg-rune-core = { path = "../../crates/rune-core", version = "^0.7.1-dev"}

--- a/proc-blocks/most_confident_indices/Cargo.toml
+++ b/proc-blocks/most_confident_indices/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "most_confident_indices"
-version = "0.6.1-dev"
+version = "0.7.0"
 edition = "2018"
 publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-hotg-rune-proc-blocks = { path = "../proc-blocks", version = "^0.6.1-dev"}
-hotg-rune-core = { path = "../../crates/rune-core", version = "^0.6.1-dev"}
+hotg-rune-proc-blocks = { path = "../proc-blocks", version = "^0.7.0"}
+hotg-rune-core = { path = "../../crates/rune-core", version = "^0.7.0"}

--- a/proc-blocks/noise-filtering/Cargo.toml
+++ b/proc-blocks/noise-filtering/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "noise-filtering"
-version = "0.6.1-dev"
+version = "0.7.0"
 edition = "2018"
 publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-hotg-rune-core = { path = "../../crates/rune-core", version = "^0.6.1-dev"}
-hotg-rune-proc-blocks = { path = "../proc-blocks", version = "^0.6.1-dev"}
+hotg-rune-core = { path = "../../crates/rune-core", version = "^0.7.0"}
+hotg-rune-proc-blocks = { path = "../proc-blocks", version = "^0.7.0"}
 libm = "0.2.1"
 paste = "1.0.5"

--- a/proc-blocks/noise-filtering/Cargo.toml
+++ b/proc-blocks/noise-filtering/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "noise-filtering"
-version = "0.7.0"
+version = "0.7.1-dev"
 edition = "2018"
 publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-hotg-rune-core = { path = "../../crates/rune-core", version = "^0.7.0"}
-hotg-rune-proc-blocks = { path = "../proc-blocks", version = "^0.7.0"}
+hotg-rune-core = { path = "../../crates/rune-core", version = "^0.7.1-dev"}
+hotg-rune-proc-blocks = { path = "../proc-blocks", version = "^0.7.1-dev"}
 libm = "0.2.1"
 paste = "1.0.5"

--- a/proc-blocks/normalize/Cargo.toml
+++ b/proc-blocks/normalize/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "normalize"
-version = "0.7.0"
+version = "0.7.1-dev"
 authors = ["The Rune Developers <developers@hotg.ai>"]
 edition = "2018"
 publish = false
@@ -8,4 +8,4 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-hotg-rune-proc-blocks = { path = "../proc-blocks", version = "^0.7.0"}
+hotg-rune-proc-blocks = { path = "../proc-blocks", version = "^0.7.1-dev"}

--- a/proc-blocks/normalize/Cargo.toml
+++ b/proc-blocks/normalize/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "normalize"
-version = "0.6.1-dev"
+version = "0.7.0"
 authors = ["The Rune Developers <developers@hotg.ai>"]
 edition = "2018"
 publish = false
@@ -8,4 +8,4 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-hotg-rune-proc-blocks = { path = "../proc-blocks", version = "^0.6.1-dev"}
+hotg-rune-proc-blocks = { path = "../proc-blocks", version = "^0.7.0"}

--- a/proc-blocks/proc-blocks/Cargo.toml
+++ b/proc-blocks/proc-blocks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hotg-rune-proc-blocks"
-version = "0.7.0"
+version = "0.7.1-dev"
 edition = "2018"
 authors = ["The Rune Developers <developers@hotg.ai>"]
 license = "MIT OR Apache-2.0"
@@ -14,6 +14,6 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-hotg-rune-proc-block-macros = { path = "../macros", version = "^0.7.0"}
-hotg-rune-core = { path = "../../crates/rune-core", version = "^0.7.0", default-features = false }
+hotg-rune-proc-block-macros = { path = "../macros", version = "^0.7.1-dev"}
+hotg-rune-core = { path = "../../crates/rune-core", version = "^0.7.1-dev", default-features = false }
 serde = { version = "1.0.126", default-features = false, features = ["derive", "alloc"] }

--- a/proc-blocks/proc-blocks/Cargo.toml
+++ b/proc-blocks/proc-blocks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hotg-rune-proc-blocks"
-version = "0.6.1-dev"
+version = "0.7.0"
 edition = "2018"
 authors = ["The Rune Developers <developers@hotg.ai>"]
 license = "MIT OR Apache-2.0"
@@ -14,6 +14,6 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-hotg-rune-proc-block-macros = { path = "../macros", version = "^0.6.1-dev"}
-hotg-rune-core = { path = "../../crates/rune-core", version = "^0.6.1-dev", default-features = false }
+hotg-rune-proc-block-macros = { path = "../macros", version = "^0.7.0"}
+hotg-rune-core = { path = "../../crates/rune-core", version = "^0.7.0", default-features = false }
 serde = { version = "1.0.126", default-features = false, features = ["derive", "alloc"] }


### PR DESCRIPTION
Now WASM3 has put out another release we can remove the temporary `[patch]` introduced in #275 and put out a release.