### PR TITLE
rune inspect fails when no git version metadata is present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 
 ## [Unreleased] - ReleaseDate
+### Fixed
+
+- The `rune inspect` command panicked if it couldn't find metadata that only
+  exists when installing from source or GitHub Releases
+  ([#307](https://github.com/hotg-ai/rune/issues/307))
 
 ## [0.7.0] - 2021-09-07
 

--- a/crates/rune-cli/src/inspect.rs
+++ b/crates/rune-cli/src/inspect.rs
@@ -50,20 +50,21 @@ impl Inspect {
 
 fn print_meta(meta: &Metadata) {
     if let Some(build_info) = &meta.rune_cli_build_info {
-        let git = build_info
-            .version_control
-            .as_ref()
-            .expect("The project uses version control")
-            .git()
-            .expect("The project uses git");
+        let git = build_info.version_control.as_ref().and_then(|v| v.git());
 
-        println!(
-            "Compiled by: {} v{} ({} {})",
-            build_info.crate_info.name,
-            build_info.crate_info.version,
-            git.commit_short_id,
-            git.commit_timestamp.date().naive_utc(),
+        print!(
+            "Compiled by: {} v{}",
+            build_info.crate_info.name, build_info.crate_info.version,
         );
+
+        match git {
+            Some(git) => println!(
+                " ({} {})",
+                git.commit_short_id,
+                git.commit_timestamp.date().naive_utc(),
+            ),
+            None => println!(),
+        }
     }
 
     if let Some(SimplifiedRune { capabilities }) = &meta.simplified_rune {


### PR DESCRIPTION
Fixes #307.