### PR TITLE
Allow proc block inputs to have "equivalent" shapes and remove the HasOutputs trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 
 ## [Unreleased] - ReleaseDate
+
+### Removed
+
+- The `hotg_rune_core::HasOutputs` trait has been removed. Processing blocks
+  should prefer to make assertions as needed.
+
 ### Fixed
 
 - The `rune inspect` command panicked if it couldn't find metadata that only

--- a/crates/rune-core/src/lib.rs
+++ b/crates/rune-core/src/lib.rs
@@ -19,7 +19,7 @@ mod value;
 
 pub use crate::{
     buf_writer::BufWriter,
-    pipelines::{Sink, Source, HasOutputs},
+    pipelines::{Sink, Source},
     tensor::{Tensor, TensorView, TensorViewMut},
     value::{Value, Type, AsType, InvalidConversionError},
     pixel_format::{PixelFormat, PixelFormatConversionError},

--- a/crates/rune-core/src/pipelines.rs
+++ b/crates/rune-core/src/pipelines.rs
@@ -2,7 +2,7 @@ use crate::Value;
 
 /// A stream of data, typically something like a random number generator or
 /// sensor.
-pub trait Source: HasOutputs {
+pub trait Source {
     type Output;
 
     fn generate(&mut self) -> Self::Output;
@@ -17,8 +17,4 @@ pub trait Source: HasOutputs {
 /// A consumer of data.
 pub trait Sink<Input> {
     fn consume(&mut self, input: Input);
-}
-
-pub trait HasOutputs {
-    fn set_output_dimensions(&mut self, _dimensions: &[usize]) {}
 }

--- a/crates/rune-core/src/shape.rs
+++ b/crates/rune-core/src/shape.rs
@@ -46,6 +46,30 @@ impl<'a> Shape<'a> {
 
         Shape::new(element_type.clone(), dimensions.clone().into_owned())
     }
+
+    /// Get a "simplified" version of this [`Shape`] which ignores dimensions
+    /// with a single length.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use hotg_rune_core::Shape;
+    /// let complex: Shape = "f32[1, 1, 3, 256, 256, 1]".parse().unwrap();
+    /// assert_eq!(complex.simplified_dimensions(), &[3, 256, 256]);
+    /// ```
+    pub fn simplified_dimensions(&self) -> &[usize] {
+        let mut dimensions = self.dimensions.as_ref();
+
+        while dimensions.len() > 1 {
+            dimensions = match dimensions {
+                [1, rest @ ..] => rest,
+                [rest @ .., 1] => rest,
+                _ => break,
+            };
+        }
+
+        dimensions
+    }
 }
 
 impl<'a> Display for Shape<'a> {

--- a/images/runicos-base/wasm/src/model.rs
+++ b/images/runicos-base/wasm/src/model.rs
@@ -1,4 +1,4 @@
-use hotg_rune_core::{Shape, TensorList, TensorListMut, HasOutputs};
+use hotg_rune_core::{Shape, TensorList, TensorListMut};
 use alloc::{
     vec::Vec,
     string::{String, ToString},
@@ -83,5 +83,3 @@ where
         outputs
     }
 }
-
-impl<Input, Output> HasOutputs for Model<Input, Output> {}

--- a/proc-blocks/audio_float_conversion/src/lib.rs
+++ b/proc-blocks/audio_float_conversion/src/lib.rs
@@ -6,7 +6,7 @@ extern crate alloc;
 #[macro_use]
 extern crate std;
 
-pub use hotg_rune_core::{HasOutputs, Tensor};
+pub use hotg_rune_core::Tensor;
 use hotg_rune_proc_blocks::{ProcBlock, Transform};
 
 // TODO: Add Generics
@@ -38,17 +38,6 @@ impl Transform<Tensor<i16>> for AudioFloatConversion {
         input.map(|_dims, &value| {
             (value as f32 / I16_MAX_AS_FLOAT).clamp(-1.0, 1.0)
         })
-    }
-}
-
-impl HasOutputs for AudioFloatConversion {
-    fn set_output_dimensions(&mut self, dimensions: &[usize]) {
-        assert_eq!(
-            dimensions.len(),
-            1,
-            "This proc block only supports 1D outputs (requested output: {:?})",
-            dimensions
-        );
     }
 }
 

--- a/proc-blocks/fft/src/lib.rs
+++ b/proc-blocks/fft/src/lib.rs
@@ -14,7 +14,7 @@ extern crate pretty_assertions;
 pub type Fft = ShortTimeFourierTransform;
 
 use alloc::{sync::Arc, vec::Vec};
-use hotg_rune_core::{HasOutputs, Tensor};
+use hotg_rune_core::Tensor;
 use hotg_rune_proc_blocks::{ProcBlock, Transform};
 use sonogram::SpecOptionsBuilder;
 use nalgebra::DMatrix;
@@ -120,8 +120,6 @@ impl Transform<Tensor<i16>> for ShortTimeFourierTransform {
         Tensor::new_row_major(Arc::new(stft), alloc::vec![1, stft.len()])
     }
 }
-
-impl HasOutputs for ShortTimeFourierTransform {}
 
 #[cfg(test)]
 mod tests {

--- a/proc-blocks/image-normalization/src/lib.rs
+++ b/proc-blocks/image-normalization/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 
 use num_traits::{Bounded, ToPrimitive};
-use hotg_rune_core::{HasOutputs, Tensor};
+use hotg_rune_core::{Tensor};
 use hotg_rune_proc_blocks::{ProcBlock, Transform};
 
 /// A normalization routine which takes some tensor of integers and fits their
@@ -37,19 +37,6 @@ where
     debug_assert!(min <= value && value <= max);
 
     Some((value - min) / (max - min))
-}
-
-impl HasOutputs for ImageNormalization {
-    fn set_output_dimensions(&mut self, dimensions: &[usize]) {
-        match *dimensions {
-            [_, _, _, 3] => {},
-            [_, _, _, channels] => panic!(
-                "The number of channels should be either 1 or 3, found {}",
-                channels
-            ),
-            _ => panic!("The image normalization proc block only supports outputs of the form [frames, rows, columns, channels], found {:?}", dimensions),
-        }
-    }
 }
 
 #[cfg(test)]

--- a/proc-blocks/label/src/lib.rs
+++ b/proc-blocks/label/src/lib.rs
@@ -5,7 +5,7 @@ extern crate alloc;
 use core::{convert::TryInto, fmt::Debug};
 
 use alloc::vec::Vec;
-use hotg_rune_proc_blocks::{HasOutputs, Tensor, Transform, ProcBlock};
+use hotg_rune_proc_blocks::{Tensor, Transform, ProcBlock};
 
 /// A proc block which, when given a set of indices, will return their
 /// associated labels.
@@ -56,20 +56,6 @@ where
     }
 }
 
-impl HasOutputs for Label {
-    fn set_output_dimensions(&mut self, dimensions: &[usize]) {
-        match dimensions {
-            [rest @ .., _] if rest.iter().all(|d| *d == 1) => {},
-            _ => {
-                panic!(
-                    "This proc block only supports 1D outputs (requested output: {:?})",
-                    dimensions
-                );
-            },
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -78,8 +64,10 @@ mod tests {
     #[should_panic]
     fn only_works_with_1d_inputs() {
         let mut proc_block = Label::default();
+        let inputs: Tensor<u32> =
+            Tensor::new_row_major(alloc::vec![0; 1*2*3].into(), alloc::vec![1, 2, 3]);
 
-        proc_block.set_output_dimensions(&[1, 2, 3]);
+        let _ = proc_block.transform(inputs);
     }
 
     #[test]

--- a/proc-blocks/modulo/src/lib.rs
+++ b/proc-blocks/modulo/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 
 use num_traits::{FromPrimitive, ToPrimitive};
-use hotg_rune_proc_blocks::{HasOutputs, Tensor, Transform, ProcBlock};
+use hotg_rune_proc_blocks::{Tensor, Transform, ProcBlock};
 
 pub fn modulo<T>(modulus: f32, values: &mut [T])
 where
@@ -41,8 +41,6 @@ where
         })
     }
 }
-
-impl HasOutputs for Modulo {}
 
 #[cfg(test)]
 mod tests {

--- a/proc-blocks/most_confident_indices/src/lib.rs
+++ b/proc-blocks/most_confident_indices/src/lib.rs
@@ -5,7 +5,7 @@ extern crate alloc;
 use core::{convert::TryInto, fmt::Debug};
 
 use alloc::vec::Vec;
-use hotg_rune_core::{HasOutputs, Tensor};
+use hotg_rune_core::Tensor;
 use hotg_rune_proc_blocks::{ProcBlock, Transform};
 
 /// A proc block which, when given a list of confidences, will return the
@@ -51,17 +51,6 @@ impl<T: PartialOrd + Copy> Transform<Tensor<T>> for MostConfidentIndices {
     }
 }
 
-impl HasOutputs for MostConfidentIndices {
-    fn set_output_dimensions(&mut self, dimensions: &[usize]) {
-        match *dimensions {
-            [count] => {
-                self.count = count;
-            },
-            _ => panic!("This proc block only supports 1D outputs (requested output: {:?})", dimensions),
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -70,8 +59,10 @@ mod tests {
     #[should_panic]
     fn only_works_with_1d() {
         let mut proc_block = MostConfidentIndices::default();
+        let input: Tensor<u32> =
+            Tensor::new_row_major(alloc::vec![0; 6].into(), alloc::vec![1, 2, 3]);
 
-        proc_block.set_output_dimensions(&[1, 2, 3]);
+        let _ = proc_block.transform(input);
     }
 
     #[test]

--- a/proc-blocks/noise-filtering/src/lib.rs
+++ b/proc-blocks/noise-filtering/src/lib.rs
@@ -11,7 +11,7 @@ mod noise_reduction;
 pub use noise_reduction::NoiseReduction;
 pub use gain_control::GainControl;
 
-use hotg_rune_core::{HasOutputs, Tensor};
+use hotg_rune_core::Tensor;
 use hotg_rune_proc_blocks::{ProcBlock, Transform};
 
 #[derive(Debug, Default, Clone, PartialEq, ProcBlock)]
@@ -62,8 +62,4 @@ impl Transform<Tensor<u32>> for NoiseFiltering {
                 as i8
         })
     }
-}
-
-impl HasOutputs for NoiseFiltering {
-    fn set_output_dimensions(&mut self, _dimensions: &[usize]) {}
 }

--- a/proc-blocks/noise-filtering/src/noise_reduction.rs
+++ b/proc-blocks/noise-filtering/src/noise_reduction.rs
@@ -5,7 +5,7 @@
 extern crate alloc;
 
 use alloc::vec::Vec;
-use hotg_rune_core::{HasOutputs, Tensor};
+use hotg_rune_core::Tensor;
 
 const NOISE_REDUCTION_BITS: usize = 14;
 
@@ -62,7 +62,13 @@ impl NoiseReduction {
         // make sure we have the right estimate buffer size and panic if we
         // don't. This works because the input and output have the same
         // dimensions.
-        self.set_output_dimensions(input.dimensions());
+        let shape = input.shape();
+        assert_eq!(
+            shape.simplified_dimensions().len(),
+            1,
+            "The input tensor should only have data in one dimension, found {}",
+            shape,
+        );
 
         let signal = input.make_elements_mut();
 
@@ -118,18 +124,6 @@ fn scale(number: f32) -> u16 {
 fn unscale(number: u16) -> f32 {
     let scale_factor: f32 = (1 << NOISE_REDUCTION_BITS) as f32;
     number as f32 / scale_factor
-}
-
-impl HasOutputs for NoiseReduction {
-    fn set_output_dimensions(&mut self, dimensions: &[usize]) {
-        match *dimensions {
-            [1, len, ] => self.estimate.resize(len, 0),
-            _ => panic!(
-                "This transform only supports outputs of the form [1, _], not {:?}",
-                dimensions
-            ),
-        }
-    }
 }
 
 #[cfg(test)]

--- a/proc-blocks/normalize/src/lib.rs
+++ b/proc-blocks/normalize/src/lib.rs
@@ -7,7 +7,7 @@ use core::{
     fmt::Debug,
     ops::{Div, Sub},
 };
-use hotg_rune_proc_blocks::{Transform, HasOutputs, Tensor};
+use hotg_rune_proc_blocks::{Transform, Tensor};
 
 pub fn normalize<T>(input: &mut [T])
 where
@@ -59,8 +59,6 @@ where
         input
     }
 }
-
-impl HasOutputs for Normalize {}
 
 fn min_max<'a, I, T>(items: I) -> Option<(T, T)>
 where

--- a/proc-blocks/proc-blocks/src/lib.rs
+++ b/proc-blocks/proc-blocks/src/lib.rs
@@ -4,7 +4,7 @@ extern crate alloc;
 
 mod descriptor;
 
-pub use hotg_rune_core::{HasOutputs, Tensor};
+pub use hotg_rune_core::Tensor;
 pub use hotg_rune_proc_block_macros::ProcBlock;
 pub use descriptor::*;
 


### PR DESCRIPTION
Fixes #313.