### PR TITLE
Reading metadata from a non-WebAssembly file creates an infinite iterator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 
 ## [Unreleased] - ReleaseDate
+
 ### Fixed
 
 - The `rune inspect` command panicked if it couldn't find metadata that only
   exists when installing from source or GitHub Releases
   ([#307](https://github.com/hotg-ai/rune/issues/307))
+- Resolved an issue where trying to read the metadata from a Rune (done as part
+  of `rune run` and `rune inspect`) would enter an infinite loop when passed a
+  file that doesn't contain WebAssembly
+  ([#318](https://github.com/hotg-ai/rune/pull/318))
 
 ## [0.7.0] - 2021-09-07
 

--- a/crates/rune-cli/src/graph.rs
+++ b/crates/rune-cli/src/graph.rs
@@ -41,6 +41,9 @@ impl Graph {
         if bytes.starts_with(WASM_MAGIC_BYTES) {
             // It's a compiled Rune
             Metadata::from_wasm_binary(&bytes)
+                .context(
+                    "Unable to extract metadata from the WebAssembly module",
+                )?
                 .take_rune()
                 .context("Unable to load the Rune metadata from the input")
         } else {

--- a/crates/rune-cli/src/run/command.rs
+++ b/crates/rune-cli/src/run/command.rs
@@ -111,7 +111,7 @@ impl Run {
 
         self.register_capabilities(&mut img)?;
 
-        resources::load_from_custom_sections(&mut img, rune);
+        resources::load_from_custom_sections(&mut img, rune)?;
         resources::load_from_files(&mut img, &self.file_resources);
         resources::load_from_strings(&mut img, &self.string_resources);
 

--- a/crates/rune-cli/src/run/mod.rs
+++ b/crates/rune-cli/src/run/mod.rs
@@ -3,8 +3,8 @@ pub mod command;
 pub mod image;
 pub mod multi;
 pub mod raw;
-pub mod sound;
 mod resources;
+pub mod sound;
 
 use hotg_rune_runtime::ParameterError;
 


### PR DESCRIPTION
Because of the way `wasmparser`'s `Parser::parse_all()` method is implemented, triggering a "bad magic number" error won't let the parser make any progress, meaning if you *don't* `break` on errors you'll get an infinite iterator. 

Later on we skip any errors and try to iterate over every `Payload` in the infinite iterator, causing commands like `rune inspect` and `rune run` to run forever.

Fixes #315.