### PR TITLE
Removed the unnecessary HasOutputs trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,7 +108,6 @@ dependencies = [
 name = "audio_float_conversion"
 version = "0.7.1-dev"
 dependencies = [
- "hotg-rune-core",
  "hotg-rune-proc-blocks",
  "pretty_assertions",
 ]
@@ -861,7 +860,6 @@ checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 name = "fft"
 version = "0.7.1-dev"
 dependencies = [
- "hotg-rune-core",
  "hotg-rune-proc-blocks",
  "hound",
  "libm",
@@ -1321,7 +1319,6 @@ dependencies = [
 name = "image-normalization"
 version = "0.7.1-dev"
 dependencies = [
- "hotg-rune-core",
  "hotg-rune-proc-blocks",
  "num-traits",
 ]
@@ -1437,7 +1434,6 @@ dependencies = [
 name = "label"
 version = "0.7.1-dev"
 dependencies = [
- "hotg-rune-core",
  "hotg-rune-proc-blocks",
 ]
 
@@ -1706,7 +1702,6 @@ checksum = "0debeb9fcf88823ea64d64e4a815ab1643f33127d995978e099942ce38f25238"
 name = "most_confident_indices"
 version = "0.7.1-dev"
 dependencies = [
- "hotg-rune-core",
  "hotg-rune-proc-blocks",
 ]
 
@@ -1741,7 +1736,6 @@ dependencies = [
 name = "noise-filtering"
 version = "0.7.1-dev"
 dependencies = [
- "hotg-rune-core",
  "hotg-rune-proc-blocks",
  "libm",
  "paste 1.0.5",

--- a/crates/compiler/src/codegen/generate_rune_graph_section.rs
+++ b/crates/compiler/src/codegen/generate_rune_graph_section.rs
@@ -4,12 +4,17 @@ use legion::{
     systems::CommandBuffer,
     world::SubWorld,
 };
-use crate::{BuildContext, codegen::{
+use crate::{
+    BuildContext,
+    codegen::{
         ModelSummary, OutputSummary, ProcBlockSummary, RuneGraph, TensorId,
-    }, lowering::{
+    },
+    lowering::{
         Inputs, Model, ModelFile, Name, Outputs, ProcBlock, Resource, Sink,
         Source, Tensor,
-    }, parse::{ResourceName, ResourceOrString}};
+    },
+    parse::{ResourceName, ResourceOrString},
+};
 
 use super::{CapabilitySummary, RuneSummary};
 

--- a/crates/rune-cli/src/lib.rs
+++ b/crates/rune-cli/src/lib.rs
@@ -11,7 +11,6 @@ pub use crate::{
     build::Build, version::Version, unstable::Unstable,
 };
 
-
 use codespan_reporting::term::termcolor;
 use env_logger::WriteStyle;
 

--- a/crates/rune-core/src/lib.rs
+++ b/crates/rune-core/src/lib.rs
@@ -8,7 +8,6 @@ extern crate alloc;
 
 mod buf_writer;
 mod logging;
-mod pipelines;
 mod pixel_format;
 pub mod reflect;
 mod resources;
@@ -19,7 +18,6 @@ mod value;
 
 pub use crate::{
     buf_writer::BufWriter,
-    pipelines::{Sink, HasOutputs},
     tensor::{Tensor, TensorView, TensorViewMut},
     value::{Value, Type, AsType, InvalidConversionError},
     pixel_format::{PixelFormat, PixelFormatConversionError},

--- a/crates/rune-core/src/pipelines.rs
+++ b/crates/rune-core/src/pipelines.rs
@@ -1,8 +1,0 @@
-/// A consumer of data.
-pub trait Sink<Input> {
-    fn consume(&mut self, input: Input);
-}
-
-pub trait HasOutputs {
-    fn set_output_dimensions(&mut self, _dimensions: &[usize]) {}
-}

--- a/examples/debugging/identity/src/lib.rs
+++ b/examples/debugging/identity/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-use hotg_rune_core::HasOutputs;
 use hotg_rune_proc_blocks::{Transform, ProcBlock};
 
 #[derive(Debug, Default, Copy, Clone, PartialEq, ProcBlock)]
@@ -17,5 +16,3 @@ impl<T> Transform<T> for Identity {
 
     fn transform(&mut self, input: T) -> Self::Output { input }
 }
-
-impl HasOutputs for Identity {}

--- a/images/runicos-base/wasm/src/model.rs
+++ b/images/runicos-base/wasm/src/model.rs
@@ -1,4 +1,4 @@
-use hotg_rune_core::{Shape, TensorList, TensorListMut, HasOutputs};
+use hotg_rune_core::{Shape, TensorList, TensorListMut};
 use alloc::{
     vec::Vec,
     string::{String, ToString},
@@ -83,5 +83,3 @@ where
         outputs
     }
 }
-
-impl<Input, Output> HasOutputs for Model<Input, Output> {}

--- a/images/runicos-base/wasm/src/serial.rs
+++ b/images/runicos-base/wasm/src/serial.rs
@@ -1,4 +1,4 @@
-use hotg_rune_core::{Sink, outputs, Tensor};
+use hotg_rune_core::{outputs, Tensor};
 use crate::intrinsics;
 use serde::ser::{Serialize, Serializer, SerializeMap};
 use core::{fmt::Debug, cell::RefCell};
@@ -58,20 +58,18 @@ impl Serial {
             }
         }
     }
+
+    pub fn consume<T>(&mut self, input: T)
+    where
+        T: IntoSerialMessage,
+    {
+        let msg = input.into_serial_message(self.id);
+        self.consume_serializable(&msg);
+    }
 }
 
 impl Default for Serial {
     fn default() -> Self { Serial::new() }
-}
-
-impl<T> Sink<T> for Serial
-where
-    T: IntoSerialMessage,
-{
-    fn consume(&mut self, input: T) {
-        let msg = input.into_serial_message(self.id);
-        self.consume_serializable(&msg);
-    }
 }
 
 /// An intermediate trait which lets you convert from some input into a

--- a/integration-tests/compile-pass/proc-block-with-multiple-inputs-and-outputs/identity/src/lib.rs
+++ b/integration-tests/compile-pass/proc-block-with-multiple-inputs-and-outputs/identity/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-use hotg_rune_core::HasOutputs;
 use hotg_rune_proc_blocks::{Transform, ProcBlock};
 
 #[derive(Debug, Default, Copy, Clone, PartialEq, ProcBlock)]
@@ -11,5 +10,3 @@ impl<T> Transform<T> for Identity {
 
     fn transform(&mut self, input: T) -> Self::Output { input }
 }
-
-impl HasOutputs for Identity {}

--- a/proc-blocks/audio_float_conversion/Cargo.toml
+++ b/proc-blocks/audio_float_conversion/Cargo.toml
@@ -7,7 +7,6 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-hotg-rune-core = { path = "../../crates/rune-core", version = "^0.7.1-dev"}
 hotg-rune-proc-blocks = { path = "../proc-blocks", version = "^0.7.1-dev"}
 
 [dev-dependencies]

--- a/proc-blocks/audio_float_conversion/src/lib.rs
+++ b/proc-blocks/audio_float_conversion/src/lib.rs
@@ -6,8 +6,7 @@ extern crate alloc;
 #[macro_use]
 extern crate std;
 
-pub use hotg_rune_core::{HasOutputs, Tensor};
-use hotg_rune_proc_blocks::{ProcBlock, Transform};
+use hotg_rune_proc_blocks::{ProcBlock, Transform, Tensor};
 
 // TODO: Add Generics
 
@@ -25,6 +24,15 @@ impl AudioFloatConversion {
             i16_max_as_float: I16_MAX_AS_FLOAT,
         }
     }
+
+    fn check_input_dimensions(&self, dimensions: &[usize]) {
+        assert_eq!(
+            dimensions.len(),
+            1,
+            "This proc block only supports 1D outputs (requested output: {:?})",
+            dimensions
+        );
+    }
 }
 
 impl Default for AudioFloatConversion {
@@ -35,20 +43,10 @@ impl Transform<Tensor<i16>> for AudioFloatConversion {
     type Output = Tensor<f32>;
 
     fn transform(&mut self, input: Tensor<i16>) -> Self::Output {
+        self.check_input_dimensions(input.dimensions());
         input.map(|_dims, &value| {
             (value as f32 / I16_MAX_AS_FLOAT).clamp(-1.0, 1.0)
         })
-    }
-}
-
-impl HasOutputs for AudioFloatConversion {
-    fn set_output_dimensions(&mut self, dimensions: &[usize]) {
-        assert_eq!(
-            dimensions.len(),
-            1,
-            "This proc block only supports 1D outputs (requested output: {:?})",
-            dimensions
-        );
     }
 }
 

--- a/proc-blocks/fft/Cargo.toml
+++ b/proc-blocks/fft/Cargo.toml
@@ -8,7 +8,6 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-hotg-rune-core = { path = "../../crates/rune-core", version = "^0.7.1-dev"}
 hotg-rune-proc-blocks = { path = "../proc-blocks", version = "^0.7.1-dev"}
 hound = "3.4"
 libm = "0.2.1"

--- a/proc-blocks/fft/src/lib.rs
+++ b/proc-blocks/fft/src/lib.rs
@@ -14,8 +14,7 @@ extern crate pretty_assertions;
 pub type Fft = ShortTimeFourierTransform;
 
 use alloc::{sync::Arc, vec::Vec};
-use hotg_rune_core::{HasOutputs, Tensor};
-use hotg_rune_proc_blocks::{ProcBlock, Transform};
+use hotg_rune_proc_blocks::{ProcBlock, Transform, Tensor};
 use sonogram::SpecOptionsBuilder;
 use nalgebra::DMatrix;
 
@@ -120,8 +119,6 @@ impl Transform<Tensor<i16>> for ShortTimeFourierTransform {
         Tensor::new_row_major(Arc::new(stft), alloc::vec![1, stft.len()])
     }
 }
-
-impl HasOutputs for ShortTimeFourierTransform {}
 
 #[cfg(test)]
 mod tests {

--- a/proc-blocks/image-normalization/Cargo.toml
+++ b/proc-blocks/image-normalization/Cargo.toml
@@ -8,5 +8,4 @@ publish = false
 
 [dependencies]
 num-traits = { version = "0.2.14", default-features = false }
-hotg-rune-core = { path = "../../crates/rune-core", version = "^0.7.1-dev"}
 hotg-rune-proc-blocks = { path = "../proc-blocks", version = "^0.7.1-dev"}

--- a/proc-blocks/image-normalization/src/lib.rs
+++ b/proc-blocks/image-normalization/src/lib.rs
@@ -1,5 +1,9 @@
 #![no_std]
 
+#[cfg(test)]
+#[macro_use]
+extern crate alloc;
+
 use num_traits::{Bounded, ToPrimitive};
 use hotg_rune_proc_blocks::{ProcBlock, Transform, Tensor};
 
@@ -58,9 +62,12 @@ mod tests {
 
     #[test]
     fn normalizing_with_default_distribution_is_noop() {
-        let input: Tensor<u8> = Tensor::from([0, 127, 255]);
+        let dims = vec![1, 1, 1, 3];
+        let input: Tensor<u8> =
+            Tensor::new_row_major(vec![0, 127, 255].into(), dims.clone());
         let mut norm = ImageNormalization::default();
-        let should_be: Tensor<f32> = Tensor::from([0.0, 127.0 / 255.0, 1.0]);
+        let should_be: Tensor<f32> =
+            Tensor::new_row_major(vec![0.0, 127.0 / 255.0, 1.0].into(), dims);
 
         let got = norm.transform(input);
 

--- a/proc-blocks/label/Cargo.toml
+++ b/proc-blocks/label/Cargo.toml
@@ -8,6 +8,3 @@ publish = false
 
 [dependencies]
 hotg-rune-proc-blocks = { path = "../proc-blocks", version = "^0.7.1-dev"}
-
-[dev-dependencies]
-hotg-rune-core = { path = "../../crates/rune-core", version = "^0.7.1-dev"}

--- a/proc-blocks/label/src/lib.rs
+++ b/proc-blocks/label/src/lib.rs
@@ -5,7 +5,7 @@ extern crate alloc;
 use core::{convert::TryInto, fmt::Debug};
 
 use alloc::vec::Vec;
-use hotg_rune_proc_blocks::{HasOutputs, Tensor, Transform, ProcBlock};
+use hotg_rune_proc_blocks::{Tensor, Transform, ProcBlock};
 
 /// A proc block which, when given a set of indices, will return their
 /// associated labels.
@@ -56,20 +56,6 @@ where
     }
 }
 
-impl HasOutputs for Label {
-    fn set_output_dimensions(&mut self, dimensions: &[usize]) {
-        match dimensions {
-            [rest @ .., _] if rest.iter().all(|d| *d == 1) => {},
-            _ => {
-                panic!(
-                    "This proc block only supports 1D outputs (requested output: {:?})",
-                    dimensions
-                );
-            },
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -78,8 +64,9 @@ mod tests {
     #[should_panic]
     fn only_works_with_1d_inputs() {
         let mut proc_block = Label::default();
+        let input: Tensor<i32> = Tensor::zeroed(alloc::vec![1, 2, 3]);
 
-        proc_block.set_output_dimensions(&[1, 2, 3]);
+        let _ = proc_block.transform(input);
     }
 
     #[test]

--- a/proc-blocks/label/src/lib.rs
+++ b/proc-blocks/label/src/lib.rs
@@ -11,10 +11,10 @@ use hotg_rune_proc_blocks::{Tensor, Transform, ProcBlock};
 /// associated labels.
 ///
 /// # Examples
+///
 /// ```rust
 /// # use label::Label;
-/// # use hotg_rune_core::Tensor;
-/// # use hotg_rune_proc_blocks::Transform;
+/// # use hotg_rune_proc_blocks::{Transform, Tensor};
 /// let mut proc_block = Label::default();
 /// proc_block.set_labels(["zero", "one", "two", "three"]);
 /// let input = Tensor::new_vector(vec![3, 1, 2]);

--- a/proc-blocks/modulo/src/lib.rs
+++ b/proc-blocks/modulo/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 
 use num_traits::{FromPrimitive, ToPrimitive};
-use hotg_rune_proc_blocks::{HasOutputs, Tensor, Transform, ProcBlock};
+use hotg_rune_proc_blocks::{Tensor, Transform, ProcBlock};
 
 pub fn modulo<T>(modulus: f32, values: &mut [T])
 where
@@ -41,8 +41,6 @@ where
         })
     }
 }
-
-impl HasOutputs for Modulo {}
 
 #[cfg(test)]
 mod tests {

--- a/proc-blocks/most_confident_indices/Cargo.toml
+++ b/proc-blocks/most_confident_indices/Cargo.toml
@@ -8,4 +8,3 @@ publish = false
 
 [dependencies]
 hotg-rune-proc-blocks = { path = "../proc-blocks", version = "^0.7.1-dev"}
-hotg-rune-core = { path = "../../crates/rune-core", version = "^0.7.1-dev"}

--- a/proc-blocks/most_confident_indices/src/lib.rs
+++ b/proc-blocks/most_confident_indices/src/lib.rs
@@ -19,6 +19,21 @@ pub struct MostConfidentIndices {
 
 impl MostConfidentIndices {
     pub fn new(count: usize) -> Self { MostConfidentIndices { count } }
+
+    fn check_input_dimensions(&self, dimensions: &[usize]) {
+        match simplify_dimensions(dimensions) {
+            [count] => assert!(
+                self.count <= *count,
+                "Unable to take the top {} values from a {}-item input",
+                self.count,
+                *count
+            ),
+            other => panic!(
+                "This proc-block only works with 1D inputs, but found {:?}",
+                other
+            ),
+        }
+    }
 }
 
 impl Default for MostConfidentIndices {
@@ -30,12 +45,7 @@ impl<T: PartialOrd + Copy> Transform<Tensor<T>> for MostConfidentIndices {
 
     fn transform(&mut self, input: Tensor<T>) -> Self::Output {
         let elements = input.elements();
-        assert!(
-            self.count <= elements.len(),
-            "Unable to take the top {} values from a {}-item input",
-            self.count,
-            elements.len()
-        );
+        self.check_input_dimensions(input.dimensions());
 
         let mut indices_and_confidence: Vec<_> =
             elements.iter().copied().enumerate().collect();
@@ -50,6 +60,22 @@ impl<T: PartialOrd + Copy> Transform<Tensor<T>> for MostConfidentIndices {
     }
 }
 
+fn simplify_dimensions(mut dimensions: &[usize]) -> &[usize] {
+    while let Some(rest) = dimensions.strip_prefix(&[1]) {
+        dimensions = rest;
+    }
+    while let Some(rest) = dimensions.strip_suffix(&[1]) {
+        dimensions = rest;
+    }
+
+    if dimensions.is_empty() {
+        // The input dimensions were just a series of 1's (e.g. [1, 1, ... , 1])
+        &[1]
+    } else {
+        dimensions
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -59,6 +85,14 @@ mod tests {
     fn only_works_with_1d() {
         let mut proc_block = MostConfidentIndices::default();
         let input: Tensor<i32> = Tensor::zeroed(alloc::vec![1, 2, 3]);
+
+        let _ = proc_block.transform(input);
+    }
+
+    #[test]
+    fn tensors_equivalent_to_1d_are_okay_too() {
+        let mut proc_block = MostConfidentIndices::default();
+        let input: Tensor<i32> = Tensor::zeroed(alloc::vec![1, 5, 1, 1, 1]);
 
         let _ = proc_block.transform(input);
     }

--- a/proc-blocks/most_confident_indices/src/lib.rs
+++ b/proc-blocks/most_confident_indices/src/lib.rs
@@ -5,8 +5,7 @@ extern crate alloc;
 use core::{convert::TryInto, fmt::Debug};
 
 use alloc::vec::Vec;
-use hotg_rune_core::{HasOutputs, Tensor};
-use hotg_rune_proc_blocks::{ProcBlock, Transform};
+use hotg_rune_proc_blocks::{ProcBlock, Transform, Tensor};
 
 /// A proc block which, when given a list of confidences, will return the
 /// indices of the top N most confident values.
@@ -51,17 +50,6 @@ impl<T: PartialOrd + Copy> Transform<Tensor<T>> for MostConfidentIndices {
     }
 }
 
-impl HasOutputs for MostConfidentIndices {
-    fn set_output_dimensions(&mut self, dimensions: &[usize]) {
-        match *dimensions {
-            [count] => {
-                self.count = count;
-            },
-            _ => panic!("This proc block only supports 1D outputs (requested output: {:?})", dimensions),
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -70,8 +58,9 @@ mod tests {
     #[should_panic]
     fn only_works_with_1d() {
         let mut proc_block = MostConfidentIndices::default();
+        let input: Tensor<i32> = Tensor::zeroed(alloc::vec![1, 2, 3]);
 
-        proc_block.set_output_dimensions(&[1, 2, 3]);
+        let _ = proc_block.transform(input);
     }
 
     #[test]

--- a/proc-blocks/noise-filtering/Cargo.toml
+++ b/proc-blocks/noise-filtering/Cargo.toml
@@ -7,7 +7,6 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-hotg-rune-core = { path = "../../crates/rune-core", version = "^0.7.1-dev"}
 hotg-rune-proc-blocks = { path = "../proc-blocks", version = "^0.7.1-dev"}
 libm = "0.2.1"
 paste = "1.0.5"

--- a/proc-blocks/noise-filtering/src/gain_control.rs
+++ b/proc-blocks/noise-filtering/src/gain_control.rs
@@ -3,7 +3,7 @@
 //! [tf]: https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/experimental/microfrontend/lib/pcan_gain_control.c
 
 use alloc::vec::Vec;
-use hotg_rune_core::Tensor;
+use hotg_rune_proc_blocks::Tensor;
 
 const WIDE_DYNAMIC_FUNCTION_BITS: usize = 32;
 const WIDE_DYNAMIC_FUNCTION_LUT_SIZE: usize =

--- a/proc-blocks/noise-filtering/src/lib.rs
+++ b/proc-blocks/noise-filtering/src/lib.rs
@@ -11,8 +11,7 @@ mod noise_reduction;
 pub use noise_reduction::NoiseReduction;
 pub use gain_control::GainControl;
 
-use hotg_rune_core::{HasOutputs, Tensor};
-use hotg_rune_proc_blocks::{ProcBlock, Transform};
+use hotg_rune_proc_blocks::{ProcBlock, Transform, Tensor};
 
 #[derive(Debug, Default, Clone, PartialEq, ProcBlock)]
 pub struct NoiseFiltering {
@@ -62,8 +61,4 @@ impl Transform<Tensor<u32>> for NoiseFiltering {
                 as i8
         })
     }
-}
-
-impl HasOutputs for NoiseFiltering {
-    fn set_output_dimensions(&mut self, _dimensions: &[usize]) {}
 }

--- a/proc-blocks/normalize/src/lib.rs
+++ b/proc-blocks/normalize/src/lib.rs
@@ -7,7 +7,7 @@ use core::{
     fmt::Debug,
     ops::{Div, Sub},
 };
-use hotg_rune_proc_blocks::{Transform, HasOutputs, Tensor};
+use hotg_rune_proc_blocks::{Transform, Tensor};
 
 pub fn normalize<T>(input: &mut [T])
 where
@@ -59,8 +59,6 @@ where
         input
     }
 }
-
-impl HasOutputs for Normalize {}
 
 fn min_max<'a, I, T>(items: I) -> Option<(T, T)>
 where

--- a/proc-blocks/proc-blocks/src/lib.rs
+++ b/proc-blocks/proc-blocks/src/lib.rs
@@ -4,7 +4,7 @@ extern crate alloc;
 
 mod descriptor;
 
-pub use hotg_rune_core::{HasOutputs, Tensor};
+pub use hotg_rune_core::Tensor;
 pub use hotg_rune_proc_block_macros::ProcBlock;
 pub use descriptor::*;
 


### PR DESCRIPTION
We originally used this as a way to check that a particular node was being given an appropriate input tensor and so capabilities know what dimensions to use.

However, we now accept multiple inputs, which the `HasOutputs` method signature doesn't allow. We've also updated the generated code so capabilities are given their output dimensions [as part of the construction process](https://github.com/hotg-ai/rune/blob/174ffae7e18a9942dde41ccce46596af4412f83e/images/runicos-base/wasm/src/capability.rs#L13).

This is part of the overall process of simplifying proc blocks (see #328).