### PR TITLE
Let integration tests handle non-deterministic error messages

### DIFF
--- a/integration-tests/compile-fail/simple-loop/another_model.stderr
+++ b/integration-tests/compile-fail/simple-loop/another_model.stderr
@@ -1,0 +1,1 @@
+... which passes data to "another_model"

--- a/integration-tests/compile-fail/simple-loop/completing_the_cycle.stderr
+++ b/integration-tests/compile-fail/simple-loop/completing_the_cycle.stderr
@@ -1,0 +1,1 @@
+, completing the cycle.

--- a/integration-tests/compile-fail/simple-loop/hints.stderr
+++ b/integration-tests/compile-fail/simple-loop/hints.stderr
@@ -1,5 +1,0 @@
-1 │ version: 1
-  │ ^
-  │
-  = ... which passes data to "some_model"...
-  = ... which passes data to "another_model", completing the cycle.

--- a/integration-tests/compile-fail/simple-loop/main-error-message.stderr
+++ b/integration-tests/compile-fail/simple-loop/main-error-message.stderr
@@ -1,1 +1,1 @@
-Cycle detected when checking "another_model"
+Cycle detected when checking

--- a/integration-tests/compile-fail/simple-loop/some_model.stderr
+++ b/integration-tests/compile-fail/simple-loop/some_model.stderr
@@ -1,0 +1,1 @@
+... which passes data to "some_model"


### PR DESCRIPTION
This is a temporary workaround to unblock #346 and fix spurious test failures.