### PR TITLE
Let models have an "args" dictionary to specify the model format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - You can now specify a model's format by setting the `format` field under
-  `args` to one of `tflite`, `tensorflow`, or `onnx`
+  `args` to one of `tensorflow-lite`, `tensorflow`, or `onnx`
   - Note that this will just ask the runtime to load a particular model, there
     is no guarantee it will be supported
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- You can now specify a model's format by setting the `format` field under
+  `args` to one of `tflite`, `tensorflow`, or `onnx`
+  - Note that this will just ask the runtime to load a particular model, there
+    is no guarantee it will be supported
+
 ### Changed
 
 - The `hotg-rune-wasmer-runtime` and `hotg-rune-wasm3-runtime` crates have been
   merged into `hotg-rune-runtime`
+
 ## [0.10.0] - 2021-10-25
 
 ### Added

--- a/bindings/web/src/Runefile.ts
+++ b/bindings/web/src/Runefile.ts
@@ -84,6 +84,9 @@ export interface DocumentV1 {
  * A ML model which will be executed by the runtime.
  */
 export interface ModelStage {
+  args?: {
+    [k: string]: string;
+  };
   /**
    * Tensors to use as input to this model.
    */

--- a/crates/compiler/runefile-schema.json
+++ b/crates/compiler/runefile-schema.json
@@ -87,6 +87,12 @@
         "model"
       ],
       "properties": {
+        "args": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "inputs": {
           "description": "Tensors to use as input to this model.",
           "type": "array",

--- a/crates/compiler/src/codegen/generate_lib_rs.rs
+++ b/crates/compiler/src/codegen/generate_lib_rs.rs
@@ -517,7 +517,7 @@ where
     let output_descriptors: TokenStream =
         tensor_descriptors(&outputs.tensors, get_tensor);
 
-    let mimetype = "application/tflite-model";
+    let mimetype = model.format.mimetype();
 
     quote! {
         let mut #name = hotg_runicos_base_wasm::Model::load(

--- a/crates/compiler/src/lowering/components.rs
+++ b/crates/compiler/src/lowering/components.rs
@@ -3,16 +3,20 @@
 use std::{
     borrow::Borrow,
     collections::HashMap,
+    error::Error,
     fmt::{self, Display, Formatter},
     hash::Hash,
     ops::Deref,
     path::PathBuf,
+    str::FromStr,
     sync::Arc,
 };
 use hotg_rune_core::Shape;
 use indexmap::IndexMap;
 use legion::Entity;
-use crate::parse::{Path, ResourceType, Value};
+use crate::{
+    parse::{Path, ResourceType, Value},
+};
 
 /// An output.
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -51,6 +55,7 @@ impl<'a> From<&'a str> for SinkKind {
 #[serde(rename_all = "kebab-case")]
 pub struct Model {
     pub model_file: ModelFile,
+    pub format: ModelFormat,
     pub args: IndexMap<String, String>,
 }
 
@@ -290,3 +295,51 @@ impl Deref for ModelData {
 
     fn deref(&self) -> &Self::Target { &self.0 }
 }
+
+#[derive(
+    Debug, Copy, Clone, PartialEq, serde::Serialize, serde::Deserialize,
+)]
+#[non_exhaustive]
+pub enum ModelFormat {
+    TensorFlowLite,
+    TensorFlow,
+    ONNX,
+}
+
+impl Default for ModelFormat {
+    fn default() -> Self { ModelFormat::TensorFlowLite }
+}
+
+impl FromStr for ModelFormat {
+    type Err = UnknownFormatError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "tensorflow-lite" => Ok(ModelFormat::TensorFlowLite),
+            "tensorflow" => Ok(ModelFormat::TensorFlow),
+            "onnx" => Ok(ModelFormat::ONNX),
+            other => Err(UnknownFormatError {
+                format: other.to_string(),
+                expected: &["tensorflow-lite", "tensorflow", "onnx"],
+            }),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct UnknownFormatError {
+    pub format: String,
+    pub expected: &'static [&'static str],
+}
+
+impl Display for UnknownFormatError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Expected the format to be one of {:?}, but found \"{}\"",
+            self.expected, self.format
+        )
+    }
+}
+
+impl Error for UnknownFormatError {}

--- a/crates/compiler/src/lowering/components.rs
+++ b/crates/compiler/src/lowering/components.rs
@@ -10,6 +10,7 @@ use std::{
     sync::Arc,
 };
 use hotg_rune_core::Shape;
+use indexmap::IndexMap;
 use legion::Entity;
 use crate::parse::{Path, ResourceType, Value};
 
@@ -50,6 +51,7 @@ impl<'a> From<&'a str> for SinkKind {
 #[serde(rename_all = "kebab-case")]
 pub struct Model {
     pub model_file: ModelFile,
+    pub args: IndexMap<String, String>,
 }
 
 /// Where to load a model from.

--- a/crates/compiler/src/lowering/components.rs
+++ b/crates/compiler/src/lowering/components.rs
@@ -306,6 +306,16 @@ pub enum ModelFormat {
     ONNX,
 }
 
+impl ModelFormat {
+    pub fn mimetype(self) -> &'static str {
+        match self {
+            ModelFormat::TensorFlowLite => hotg_rune_core::TFLITE_MIMETYPE,
+            ModelFormat::TensorFlow => hotg_rune_core::TF_MIMETYPE,
+            ModelFormat::ONNX => hotg_rune_core::ONNX_MIMETYPE,
+        }
+    }
+}
+
 impl Default for ModelFormat {
     fn default() -> Self { ModelFormat::TensorFlowLite }
 }

--- a/crates/compiler/src/parse/yaml.rs
+++ b/crates/compiler/src/parse/yaml.rs
@@ -315,6 +315,8 @@ pub struct ModelStage {
     /// The tensors that this model outputs.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub outputs: Vec<Type>,
+    #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
+    pub args: IndexMap<String, String>,
 }
 
 /// A stage which executes a procedural block.
@@ -1066,6 +1068,7 @@ pipeline:
                     model: "./model.tflite".into(),
                     inputs: vec!["fft".parse().unwrap()],
                     outputs: vec![ty!(i8[6])],
+                    args: IndexMap::new(),
                 }),
             },
             resources: map![],

--- a/crates/compiler/src/type_check/mod.rs
+++ b/crates/compiler/src/type_check/mod.rs
@@ -2,12 +2,17 @@
 
 mod check_for_loops;
 mod components;
+mod model_args_are_consumed;
 
 pub use components::*;
 
 use legion::Registry;
 use crate::phases::Phase;
 
-pub fn phase() -> Phase { Phase::new().and_then(check_for_loops::run_system) }
+pub fn phase() -> Phase {
+    Phase::new()
+        .and_then(check_for_loops::run_system)
+        .and_then(model_args_are_consumed::run_system)
+}
 
 pub(crate) fn register_components(_registry: &mut Registry<String>) {}

--- a/crates/compiler/src/type_check/model_args_are_consumed.rs
+++ b/crates/compiler/src/type_check/model_args_are_consumed.rs
@@ -1,0 +1,38 @@
+use codespan::Span;
+use codespan_reporting::diagnostic::{Diagnostic, Label};
+use legion::{Query, world::SubWorld};
+use crate::{
+    Diagnostics,
+    lowering::{Model, Name},
+};
+
+/// Check that all model arguments were consumed during the lowering process,
+/// emitting a warning for any that weren't.
+#[legion::system]
+pub(crate) fn run(
+    world: &SubWorld,
+    #[resource] diags: &mut Diagnostics,
+    models: &mut Query<(&Name, &Span, &Model)>,
+) {
+    models.for_each(world, |(n, s, m)| {
+        if !m.args.is_empty() {
+            let unused_args: Vec<_> =
+                m.args.keys().map(|s| s.as_str()).collect();
+            diags.push(unused_model_arguments_diagnostic(n, *s, &unused_args));
+        }
+    });
+}
+
+fn unused_model_arguments_diagnostic(
+    name: &Name,
+    span: Span,
+    unused_args: &[&str],
+) -> Diagnostic<()> {
+    Diagnostic::warning()
+        .with_message(format!(
+            "Unused arguments for {}: {}",
+            name,
+            unused_args.join(", ")
+        ))
+        .with_labels(vec![Label::primary((), span)])
+}

--- a/crates/rune-core/src/lib.rs
+++ b/crates/rune-core/src/lib.rs
@@ -38,6 +38,10 @@ pub use crate::{
 
 /// The mimetype used for a TensorFlow Lite model.
 pub const TFLITE_MIMETYPE: &str = "application/tflite-model";
+/// The mimetype used for a TensorFlow model.
+pub const TF_MIMETYPE: &str = "application/tf-model";
+/// The mimetype used for a ONNX model.
+pub const ONNX_MIMETYPE: &str = "application/onnx-model";
 
 /// The version number for this crate.
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/integration-tests/compile-fail/unknown-model-format/Runefile.yml
+++ b/integration-tests/compile-fail/unknown-model-format/Runefile.yml
@@ -1,0 +1,12 @@
+version: 1
+image: runicos/base
+
+pipeline:
+  some_model:
+    model: $MODEL_FILE
+    args:
+      format: unknown-format
+
+resources:
+  MODEL_FILE:
+    type: binary

--- a/integration-tests/compile-fail/unknown-model-format/expected.stderr
+++ b/integration-tests/compile-fail/unknown-model-format/expected.stderr
@@ -1,0 +1,1 @@
+error: Expected the format to be one of ["tensorflow-lite", "tensorflow", "onnx"], but found "unknown-format"

--- a/integration-tests/compile-pass/model-arguments-should-be-used/Runefile.yml
+++ b/integration-tests/compile-pass/model-arguments-should-be-used/Runefile.yml
@@ -1,0 +1,29 @@
+image: runicos/base
+version: 1
+
+pipeline:
+  input:
+    capability: RAND
+    outputs:
+      - type: i32
+        dimensions: [4]
+
+  some_model:
+    model: $MODEL
+    inputs:
+    - input
+    outputs:
+    - type: i32
+      dimensions: [4]
+    args:
+      unused_argument: asdfg
+      another_unused_argument: asd42
+
+  serial:
+    out: serial
+    inputs:
+      - input
+
+resources:
+  MODEL:
+    type: binary

--- a/integration-tests/compile-pass/model-arguments-should-be-used/warning.stderr
+++ b/integration-tests/compile-pass/model-arguments-should-be-used/warning.stderr
@@ -1,0 +1,1 @@
+warning: Unused arguments for some_model: unused_argument, another_unused_argument


### PR DESCRIPTION
This gives model nodes an `args` field which is essentially a `HashMap<String, String>`. 

We also let the user specify a `format` to indicate the format this model is in (e.g. `tensorflow-lite`, `tensorflow`, or `onnx`) so that information can be passed on to the runtime using our "mimetype" mechanism. If no `format` is provided, it will default to `tensorflow-lite`.

I've added a lint which warns if any arguments in the model's `args` dictionary haven't been consumed during the lowering process. That should help people to detect typos or when they are using a Runefile with proprietary extensions with the open-source `rune` CLI.

@aminhotg, @f0rodo, and @jacekpie, [this integration test](https://github.com/hotg-ai/rune/blob/c4d9c54ff81a431bfaec7a0404ad6104069a3535/integration-tests/compile-fail/unknown-model-format/Runefile.yml#L7-L8) shows the new `args` and `format` fields, and [the expected compile error](https://github.com/hotg-ai/rune/blob/c4d9c54ff81a431bfaec7a0404ad6104069a3535/integration-tests/compile-fail/unknown-model-format/expected.stderr) shows which `format` values are valid. The runtime doesn't support TensorFlow or ONNX yet, but at some point we'll need to add a drop-down to let people tell us which format their model is in (technically, it can be inferred when they upload the model, but users will probably want a way to override it).