### PR TITLE
Allow ReadInput to return either a Tensor or a raw byte array

### DIFF
--- a/bindings/web/package.json
+++ b/bindings/web/package.json
@@ -12,7 +12,7 @@
     "dist/**"
   ],
   "scripts": {
-    "prepublish": "tsc",
+    "prepare": "tsc",
     "build": "tsc",
     "watch": "tsc --watch",
     "watch:test": "jest --watch",

--- a/bindings/web/package.json
+++ b/bindings/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hotg-ai/rune",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Execute Runes inside a JavaScript environment.",
   "repository": "https://github.com/hotg-ai/rune",
   "author": "The Rune Developers <developers@hotg.ai>",

--- a/bindings/web/src/facade.ts
+++ b/bindings/web/src/facade.ts
@@ -9,7 +9,12 @@ export type InputDescription = {
     type: CapabilityType,
     args: Partial<Record<string, number>>,
 };
-export type ReadInput = (input: InputDescription) => Tensor;
+
+/**
+ * A function that returns the desired input, either as a tensor or the raw
+ * byte buffer.
+ */
+export type ReadInput = (input: InputDescription) => Tensor | Uint8Array;
 
 export class Builder {
     private modelHandlers: Partial<Record<string, ModelConstructor>> = {};
@@ -160,7 +165,7 @@ class ImportsObject implements Imports {
 
 class LazyCapability implements Capability {
     type: CapabilityType;
-    value?: Tensor;
+    value?: Tensor | Uint8Array;
     args: Record<string, number> = {};
 
     constructor(type: CapabilityType) {
@@ -178,9 +183,11 @@ class LazyCapability implements Capability {
         if (!this.value) {
             throw new Error();
         }
-        const tensorData = this.value.dataSync()
+
+        const tensorData = this.value instanceof Uint8Array ? this.value : this.value.dataSync();
         const { buffer, byteLength, byteOffset } = tensorData;
         const bytes = new Uint8Array(buffer.slice(byteOffset, byteOffset + byteLength));
+
         dest.set(bytes);
     }
 


### PR DESCRIPTION
After reading https://github.com/tensorflow/tfjs/issues/206, it doesn't seem like tf.js supports `uint8` tensors. As a workaround, let's let people return either a tensor *or* a raw byte buffer that will be blindly copied across.