### PR TITLE
Added a workaround for Safari and BigUint64Array

### DIFF
--- a/bindings/web/rune/package.json
+++ b/bindings/web/rune/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hotg-ai/rune",
-  "version": "0.11.5",
+  "version": "0.11.6",
   "description": "Execute Runes inside a JavaScript environment.",
   "repository": "https://github.com/hotg-ai/rune",
   "homepage": "https://hotg.dev/",

--- a/bindings/web/rune/src/Tensor.ts
+++ b/bindings/web/rune/src/Tensor.ts
@@ -1,9 +1,17 @@
 import Shape from "./Shape";
 
+// Some versions of Safari doesn't support BigUint64Array and friends, and
+// it's not possible to polyfill these types because bigint is a builtin type.
+//
+// This workaround lets us use them when possible and throws an exception at
+// runtime when they aren't.
+const BigUint64ArrayShim = global.BigUint64Array ?? class { constructor() { throw new Error("BigUint64Array is not supported on this device"); } };
+const BigInt64ArrayShim = global.BigInt64Array ?? class { constructor() { throw new Error("BigInt64Array is not supported on this device"); } };
+
 const typedArrays = {
     "f64": Float64Array,
-    "i64": BigInt64Array,
-    "u64": BigUint64Array,
+    "i64": BigInt64ArrayShim,
+    "u64": BigUint64ArrayShim,
     "f32": Float32Array,
     "i32": Int32Array,
     "u32": Uint32Array,

--- a/bindings/web/rune/src/Tensor.ts
+++ b/bindings/web/rune/src/Tensor.ts
@@ -21,8 +21,17 @@ const typedArrays = {
     "i8": Int8Array,
 } as const;
 
+/**
+ * An opaque tensor.
+ */
 export default class Tensor {
+    /**
+     * The raw bytes containing the tensor data.
+     */
     public readonly elements: Uint8Array;
+    /**
+     * The tensor's shape (element type and dimensions).
+     */
     public readonly shape: Shape;
 
     constructor(shape: Shape, elements: Uint8Array) {
@@ -30,16 +39,68 @@ export default class Tensor {
         this.elements = elements;
     }
 
+    /**
+     * View this tensor's data as an array of 64-bit floats.
+     *
+     * This will fail if this isn't a f64 tensor.
+     */
     public asTypedArray(elementType: "f64"): Float64Array;
+    /**
+     * View this tensor's data as an array of 64-bit signed integers.
+     *
+     * This will fail if this isn't a i64 tensor. It may also fail on
+     * versions of Safari because they don't support BigInt64Array.
+     */
     public asTypedArray(elementType: "i64"): BigInt64Array;
+    /**
+     * View this tensor's data as an array of 64-bit unsigned integers.
+     *
+     * This will fail if this isn't a u64 tensor. It may also fail on
+     * versions of Safari because they don't support BigUint64Array.
+     */
     public asTypedArray(elementType: "u64"): BigUint64Array;
+    /**
+     * View this tensor's data as an array of 32-bit floats.
+     *
+     * This will fail if this isn't a f32 tensor.
+     */
     public asTypedArray(elementType: "f32"): Float32Array;
+    /**
+     * View this tensor's data as an array of 32-bit signed integers.
+     *
+     * This will fail if this isn't a i32 tensor.
+     */
     public asTypedArray(elementType: "i32"): Int32Array;
+    /**
+     * View this tensor's data as an array of 32-bit unsigned integers.
+     *
+     * This will fail if this isn't a u32 tensor.
+     */
     public asTypedArray(elementType: "u32"): Uint32Array;
-    public asTypedArray(elementType: "u16"): Uint16Array;
+    /**
+     * View this tensor's data as an array of 16-bit signed integers.
+     *
+     * This will fail if this isn't a i16 tensor.
+     */
     public asTypedArray(elementType: "i16"): Int16Array;
-    public asTypedArray(elementType: "u8"): Uint8ClampedArray;
+    /**
+     * View this tensor's data as an array of 16-bit unsigned integers.
+     *
+     * This will fail if this isn't a u16 tensor.
+     */
+    public asTypedArray(elementType: "u16"): Uint16Array;
+    /**
+     * View this tensor's data as an array of 8-bit signed integers.
+     *
+     * This will fail if this isn't a i8 tensor.
+     */
     public asTypedArray(elementType: "i8"): Int8Array;
+    /**
+     * View this tensor's data as an array of 8-bit unsigned integers.
+     *
+     * This will fail if this isn't a u8 tensor.
+     */
+    public asTypedArray(elementType: "u8"): Uint8ClampedArray;
 
     public asTypedArray(elementType: keyof typeof typedArrays): ArrayBuffer {
         if (this.shape.type != elementType) {


### PR DESCRIPTION
The [release notes](https://developer.apple.com/safari/technology-preview/release-notes/#r121) for Safari version 121 say that `BigUint64Array` and `BigInt64Array` are supported ([caniuse says it was released in October 2021](https://caniuse.com/mdn-javascript_builtins_bigint64array_bigint64array)), but in practice we've found Safari browsers where they aren't defined. 

To avoid a `ReferenceError` on these browsers we can use a shim class which will throw an exception whenever you try to construct these unsupported types. According to https://github.com/zloirock/core-js/issues/381 and [the `core-js` README](https://github.com/zloirock/core-js#missing-polyfills) it isn't possible to polyfill bigint, so this is probably the best we can do.

Fixes #412.