### PR TITLE
Command for "rune inspect proc-block"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1015,6 +1015,7 @@ dependencies = [
  "env_logger",
  "hotg-rune-compiler",
  "hotg-rune-core",
+ "hotg-rune-proc-blocks",
  "hotg-rune-runtime",
  "hotg-runecoral",
  "hotg-runicos-base-runtime",

--- a/crates/compiler/src/codegen/generate_rust_toolchain_toml.rs
+++ b/crates/compiler/src/codegen/generate_rust_toolchain_toml.rs
@@ -1,40 +1,13 @@
 use legion::systems::CommandBuffer;
-use toml::Value;
 
 use crate::codegen::File;
 
 #[legion::system]
 pub(crate) fn run(cmd: &mut CommandBuffer) {
-    let rust_toolchain = rust_toolchain();
+    let rust_toolchain = crate::rust_toolchain();
     let contents = toml::to_vec(&rust_toolchain)
         .expect("We can always serialize a hard-coded TOML object");
     let file = File::new("rust-toolchain.toml", contents);
 
     cmd.push((file,));
-}
-
-/// Get a copy of the `rust-toolchain.toml` file used by the Rune project
-/// itself.
-fn rust_toolchain() -> Value {
-    toml::toml! {
-        [toolchain]
-        channel = "nightly-2021-10-15"
-        targets = ["wasm32-unknown-unknown"]
-        components = ["rustfmt"]
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn generated_toolchain_file_is_always_in_sync_with_repo() {
-        let original = include_str!("../../../../rust-toolchain.toml");
-        let original: Value = toml::from_str(original).unwrap();
-
-        let got = rust_toolchain();
-
-        assert_eq!(got, original);
-    }
 }

--- a/crates/compiler/src/lib.rs
+++ b/crates/compiler/src/lib.rs
@@ -38,10 +38,12 @@ pub mod lowering;
 pub mod parse;
 mod phases;
 pub mod serialize;
+mod toolchain;
 pub mod type_check;
 
 pub use crate::{
     phases::{build, build_with_hooks, Phase},
     diagnostics::Diagnostics,
     build_context::{BuildContext, Verbosity, FeatureFlags},
+    toolchain::rust_toolchain,
 };

--- a/crates/compiler/src/toolchain.rs
+++ b/crates/compiler/src/toolchain.rs
@@ -1,0 +1,27 @@
+use cargo_toml::Value;
+
+/// Get a copy of the `rust-toolchain.toml` file used by the Rune project
+/// itself.
+pub fn rust_toolchain() -> Value {
+    toml::toml! {
+        [toolchain]
+        channel = "nightly-2021-10-15"
+        targets = ["wasm32-unknown-unknown"]
+        components = ["rustfmt"]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generated_toolchain_file_is_always_in_sync_with_repo() {
+        let original = include_str!("../../../rust-toolchain.toml");
+        let original: Value = toml::from_str(original).unwrap();
+
+        let got = rust_toolchain();
+
+        assert_eq!(got, original);
+    }
+}

--- a/crates/proc-blocks/src/descriptor.rs
+++ b/crates/proc-blocks/src/descriptor.rs
@@ -1,4 +1,8 @@
-use core::{iter::FromIterator, ops::Deref};
+use core::{
+    iter::FromIterator,
+    ops::Deref,
+    fmt::{Display, self, Formatter},
+};
 use alloc::borrow::Cow;
 
 /// A description of everything a particular proc block is capable of.
@@ -62,6 +66,24 @@ pub enum Dimensions<'a> {
     Arbitrary,
 }
 
+impl<'a> Display for Dimensions<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Dimensions::Arbitrary => write!(f, ".."),
+            Dimensions::Finite(dimensions) => {
+                for (i, dimension) in dimensions.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{}", dimension)?;
+                }
+
+                Ok(())
+            },
+        }
+    }
+}
+
 impl<'a, D: Into<Cow<'a, [Dimension]>>> From<D> for Dimensions<'a> {
     fn from(dims: D) -> Self { Dimensions::Finite(dims.into()) }
 }
@@ -72,4 +94,13 @@ impl<'a, D: Into<Cow<'a, [Dimension]>>> From<D> for Dimensions<'a> {
 pub enum Dimension {
     Any,
     Value(usize),
+}
+
+impl Display for Dimension {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Dimension::Any => write!(f, "_"),
+            Dimension::Value(dim) => write!(f, "{}", dim),
+        }
+    }
 }

--- a/crates/rune-cli/Cargo.toml
+++ b/crates/rune-cli/Cargo.toml
@@ -26,6 +26,7 @@ dotenv = "0.15.0"
 env_logger = "0.9"
 hotg-rune-compiler = { path = "../compiler", version = "^0.11.0"}
 hotg-rune-core = { path = "../rune-core", version = "^0.11.0"}
+hotg-rune-proc-blocks = { version = "0.11.3", path = "../proc-blocks" }
 hotg-rune-runtime = { path = "../runtime", version = "^0.11.0", features = ["builtins", "wasm3", "wasmer"] }
 hotg-runecoral = "0.3.6"
 hotg-runicos-base-runtime = { path = "../../images/runicos-base/runtime", version = "^0.11.0", features = ["wasm3-runtime"] }

--- a/crates/rune-cli/src/build.rs
+++ b/crates/rune-cli/src/build.rs
@@ -140,7 +140,7 @@ static DEFAULT_CACHE_DIR: Lazy<String> = Lazy::new(|| {
         .or_else(dirs::home_dir)
         .unwrap_or_else(|| PathBuf::from("."));
 
-    cache_dir.join("runes").to_string_lossy().into_owned()
+    cache_dir.join("rune").join("runes").to_string_lossy().into_owned()
 });
 
 #[derive(Debug)]

--- a/crates/rune-cli/src/inspect/mod.rs
+++ b/crates/rune-cli/src/inspect/mod.rs
@@ -1,0 +1,37 @@
+mod rune;
+
+pub(crate) use self::rune::{Metadata, CustomSection, wasm_custom_sections};
+
+use std::path::PathBuf;
+use anyhow::Error;
+use strum::VariantNames;
+use crate::Format;
+
+#[derive(Debug, Clone, PartialEq, structopt::StructOpt)]
+pub struct Inspect {
+    #[structopt(
+        short,
+        long,
+        help = "The format to use when printing output",
+        default_value = "text",
+        possible_values = Format::VARIANTS,
+        parse(try_from_str)
+    )]
+    format: Format,
+    #[structopt(help = "The File to inspect", parse(from_os_str))]
+    filename: PathBuf,
+}
+
+impl Inspect {
+    pub fn execute(self) -> Result<(), Error> {
+        let Inspect { format, filename } = self;
+
+        match filename.extension().and_then(|s| s.to_str()) {
+            Some("rune" | "wasm") => rune::inspect(format, &filename),
+            Some(other) => {
+                anyhow::bail!("Unable to inspect a \"{}\" file", other)
+            },
+            None => anyhow::bail!("Unable to inspect this file"),
+        }
+    }
+}

--- a/crates/rune-cli/src/inspect/mod.rs
+++ b/crates/rune-cli/src/inspect/mod.rs
@@ -1,3 +1,4 @@
+mod proc_block;
 mod rune;
 
 pub(crate) use self::rune::{Metadata, CustomSection, wasm_custom_sections};
@@ -18,13 +19,17 @@ pub struct Inspect {
         parse(try_from_str)
     )]
     format: Format,
-    #[structopt(help = "The File to inspect", parse(from_os_str))]
+    #[structopt(help = "The File to inspect", parse(try_from_str))]
     filename: PathBuf,
 }
 
 impl Inspect {
     pub fn execute(self) -> Result<(), Error> {
         let Inspect { format, filename } = self;
+
+        if filename.is_dir() {
+            return proc_block::inspect(format, &filename);
+        }
 
         match filename.extension().and_then(|s| s.to_str()) {
             Some("rune" | "wasm") => rune::inspect(format, &filename),

--- a/crates/rune-cli/src/inspect/proc_block.rs
+++ b/crates/rune-cli/src/inspect/proc_block.rs
@@ -1,0 +1,200 @@
+use std::{
+    path::{Path, PathBuf},
+    process::Command,
+};
+use anyhow::{Error, Context};
+use hotg_rune_proc_blocks::{
+    ProcBlockDescriptor, TransformDescriptor, TensorDescriptors,
+    TensorDescriptor,
+};
+use crate::{Format, inspect::wasm_custom_sections};
+
+pub fn inspect(format: Format, proc_block_dir: &Path) -> Result<(), Error> {
+    log::info!("Inspecting \"{}\"", proc_block_dir.display());
+
+    let dest = cache_dir(proc_block_dir);
+
+    log::debug!("Writing probe to \"{}\"", dest.display());
+
+    generate_project(&dest, proc_block_dir)
+        .context("Unable to generate the probe project")?;
+
+    let mut cmd = Command::new("cargo");
+    cmd.arg("build")
+        .arg("--target")
+        .arg("wasm32-unknown-unknown")
+        .current_dir(&dest);
+
+    log::debug!("Executing {:?}", cmd);
+
+    let status = cmd
+        .status()
+        .with_context(|| format!("Unable to start cargo"))?;
+
+    if !status.success() {
+        anyhow::bail!("Compilation failed");
+    }
+
+    let binary = dest
+        .join("target")
+        .join("wasm32-unknown-unknown")
+        .join("debug")
+        .join("probe.wasm");
+    let wasm = std::fs::read(&binary)
+        .with_context(|| format!("Unable to read \"{}\"", binary.display()))?;
+
+    log::debug!("Read {} bytes from \"{}\"", wasm.len(), binary.display());
+
+    let sections = wasm_custom_sections(&wasm)
+        .context("Unable to parse the WebAssembly module")?;
+
+    let section = sections
+        .iter()
+        .find(|s| s.name == ProcBlockDescriptor::CUSTOM_SECTION_NAME)
+        .context("Unable to locate the proc-block's metadata")?;
+
+    let metadata: ProcBlockDescriptor = serde_json::from_slice(section.data)
+        .context("Unable to parse the proc-block metadata")?;
+
+    match format {
+        Format::Json => {
+            let json = serde_json::to_string_pretty(&metadata)?;
+            println!("{}", json);
+            Ok(())
+        },
+        Format::Text => {
+            print_descriptor(&metadata);
+            Ok(())
+        },
+    }
+}
+
+fn print_descriptor(metadata: &ProcBlockDescriptor) {
+    let ProcBlockDescriptor {
+        type_name,
+        description,
+        available_transforms,
+    } = metadata;
+
+    println!("{}", type_name);
+    println!("{}", "-".repeat(type_name.chars().count()));
+
+    for line in description.lines() {
+        println!("{}", line);
+    }
+
+    if !description.is_empty() {
+        println!();
+    }
+
+    if available_transforms.is_empty() {
+        println!("(no transforms registered)");
+    } else {
+        println!("Transforms:");
+
+        for transform in available_transforms.iter() {
+            print_transform(transform);
+        }
+    }
+}
+
+fn print_transform(transform: &TransformDescriptor) {
+    let TransformDescriptor { inputs, outputs } = transform;
+
+    print!("  inputs: ");
+    print_tensor_descriptors(inputs);
+    print!("  outputs: ");
+    print_tensor_descriptors(outputs);
+}
+
+fn print_tensor_descriptors(tensors: &TensorDescriptors) {
+    if tensors.len() == 1 {
+        print_tensor_descriptor(&tensors[0]);
+        println!();
+    } else {
+        print!("(");
+        for (i, tensor) in tensors.iter().enumerate() {
+            if i > 0 {
+                print!(", ");
+            }
+
+            print_tensor_descriptor(tensor);
+        }
+        println!(")");
+    }
+}
+
+fn print_tensor_descriptor(tensor: &TensorDescriptor) {
+    let TensorDescriptor {
+        element_type,
+        dimensions,
+    } = tensor;
+    print!("{}[{}]", element_type, dimensions);
+}
+
+const CARGO_TOML_TEMPLATE: &str = r#"
+[package]
+name = "probe"
+version = "0.0.0"
+edition = "2018"
+
+[lib]
+path = "lib.rs"
+crate-type = ["cdylib"]
+
+[dependencies]
+"$NAME" = { path = "$PATH" }
+"#;
+
+const LIB_RS_TEMPLATE: &str = "
+pub use $NAME::*;
+";
+
+fn generate_project(dest: &PathBuf, filename: &Path) -> Result<(), Error> {
+    let path = filename.to_string_lossy();
+    let name = filename
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .context("Unable to determine the package's name")?;
+
+    write(
+        dest.join("Cargo.toml"),
+        CARGO_TOML_TEMPLATE
+            .replace("$PATH", &path)
+            .replace("$NAME", name),
+    )?;
+
+    let name = name.replace("-", "_");
+    write(dest.join("lib.rs"), LIB_RS_TEMPLATE.replace("$NAME", &name))?;
+
+    write(
+        dest.join("rust-toolchain.toml"),
+        hotg_rune_compiler::rust_toolchain().to_string(),
+    )?;
+
+    Ok(())
+}
+
+fn write(
+    file: impl AsRef<Path>,
+    contents: impl AsRef<[u8]>,
+) -> Result<(), Error> {
+    let file = file.as_ref();
+
+    if let Some(parent) = file.parent() {
+        std::fs::create_dir_all(parent).with_context(|| {
+            format!("Unable to create the \"{}\" directory", parent.display())
+        })?;
+    }
+
+    std::fs::write(file, contents.as_ref())
+        .with_context(|| format!("Unable to write to \"{}\"", file.display()))
+}
+
+fn cache_dir(project: &Path) -> PathBuf {
+    let cache_dir = dirs::cache_dir()
+        .or_else(dirs::home_dir)
+        .unwrap_or_else(|| project.join("target").join("probe"));
+
+    cache_dir.join("rune").join("proc-blocks")
+}


### PR DESCRIPTION
This modifies the existing `rune inspect` command so when you point it at a crate's folder on disk it will compile the crate to WebAssembly and extract the proc-block metadata.

Here is an example of what you might get if you ask for JSON output:

```console
$ cargo rune inspect ~/Documents/hotg-ai/proc-blocks/audio_float_conversion --format=json
{
  "type_name": "AudioFloatConversion",
  "description": "Convert a PCM audio clip from 16-bit signed integers to floats between 0 and\n1.",
  "available_transforms": [
    {
      "inputs": [
        {"element_type": "I16", "dimensions": "Arbitrary"}
      ],
      "outputs": [
        {"element_type": "F32", "dimensions": "Arbitrary"}
      ]
    }
  ]
}

$ cargo rune inspect ~/Documents/hotg-ai/proc-blocks/audio_float_conversion --format=text
AudioFloatConversion
--------------------
Convert a PCM audio clip from 16-bit signed integers to floats between 0 and
1.

Transforms:
  inputs: i16[..]
  outputs: f32[..]
```