### PR TITLE
chore: Update `jsonschema` to `0.16.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -886,9 +886,9 @@ checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fancy-regex"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6b8560a05112eb52f04b00e5d3790c0dd75d9d980eb8a122fb23b92a623ccf"
+checksum = "d95b4efe5be9104a4a18a9916e86654319895138be727b229820c39257c30dda"
 dependencies = [
  "bit-set",
  "regex",
@@ -948,9 +948,9 @@ checksum = "f7aea5a5909a74969507051a3b17adc84737e31a5f910559892aedce026f4d53"
 
 [[package]]
 name = "fraction"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aba3510011eee8825018be07f08d9643421de007eaf62a3bde58d89b058abfa7"
+checksum = "6bb65943183b6b3cbf00f64c181e8178217e30194381b150e4f87ec59864c803"
 dependencies = [
  "lazy_static",
  "num",
@@ -1400,18 +1400,20 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.13.3"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877e398ffb23c1c311c417ef5e72e8699c3822dbf835468f009c6ce91b6c206b"
+checksum = "4ebd40599e7f1230ce296f73b88c022b98ed66689f97eaa54bbeadc337a2ffa6"
 dependencies = [
  "ahash",
+ "anyhow",
  "base64",
  "bytecount",
  "fancy-regex",
  "fraction",
  "iso8601",
- "itoa 0.4.8",
+ "itoa 1.0.1",
  "lazy_static",
+ "memchr",
  "num-cmp",
  "parking_lot 0.12.0",
  "percent-encoding",

--- a/crates/compiler/Cargo.toml
+++ b/crates/compiler/Cargo.toml
@@ -38,5 +38,5 @@ zip = "0.5.13"
 
 [dev-dependencies]
 env_logger = "0.9.0"
-jsonschema = { version = "0.13.3", default-features = false }
+jsonschema = { version = "0.16.0", default-features = false }
 pretty_assertions = "1.0.0"


### PR DESCRIPTION
Hi! I am the author of the `jsonschema` crate you're using.

It seems you were not affected by the recent compilation issues in the `0.15.x` series, but I thought that I'll submit a PR that bumps `jsonschema` to its latest version anyway :) Hope it is ok